### PR TITLE
Consider :before and :after outline and shadow

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -44,7 +44,7 @@
     }
 
     function getScreenshotRect(selectors) {
-        var element, css, clientRect, rect;
+        var element, css, clientRect, rect, pseudo = [':before', ':after'];
         for (var i = 0; i<selectors.length; i++) {
             element = document.querySelector(selectors[i]);
             if (!element) {
@@ -63,6 +63,11 @@
             }
 
             rect = rectMerge(rect, getElementRect(css, clientRect));
+
+            for (var j = 0; j < pseudo.length; j++) {
+                css = window.getComputedStyle(element, pseudo[j]);
+                rect = rectMerge(rect, getElementRect(css, clientRect));
+            }
         }
         return roundDimensions(rect);
     }


### PR DESCRIPTION
Sometimes pseudo element could have `box-shadow` larger than its parent. In this case screenshot would not capture its shadow. Example here (moved `box-shadow` from element to `:before`): http://nda.ya.ru/3QTQuu
There is no way to capture pseudo-elements by selector, so maybe we could take `:before` and `:after` into account while calculating element rectangle?
