### PR TITLE
Need absolute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,4 +437,4 @@ for example `~/.bashrc` for `bash` or `~/.zshrc` for `zsh`).
 ## Programmatic API
 
 To use `gemini` in your scripts or build tools plugins you can use experimental 
-[programmatic API](doc/programmatic-api.md).
+[programmatic API](https://github.com/bem/gemini/blob/master/doc/programmatic-api.md).


### PR DESCRIPTION
We need here absolute link, because on bem-info we haven't article about programmatic API.
http://bem.info/tools/testing/gemini/
