### PR TITLE
Write coverage statistics to json file

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -54,13 +54,14 @@ module.exports = inherit({
                     return _this.processFile(file, tmpl, reports);
                 }))
                 .then(function() {
-                    reports.sort(function(a, b) {
-                        return a.source - b.source;
-                    });
-                    return writeIndex(reports, _this.covDir);
+                    return prepareOutputStats(reports);
                 })
-                .then(function() {
-                    return copyResources(_this.covDir);
+                .then(function(stats) {
+                    return q.all([
+                        writeIndex(stats, _this.covDir),
+                        writeStatsJson(stats, _this.covDir),
+                        copyResources(_this.covDir)
+                    ]);
                 });
             });
     },
@@ -294,25 +295,48 @@ function getPosition(originalPos, file, map) {
     return originalPos;
 }
 
-function writeIndex(reports, covDir) {
+function prepareOutputStats(reports) {
+    reports.sort(function(a, b) {
+        return a.source.localeCompare(b.source);
+    });
+
+    var stat = reports.reduce(
+        function(prev, current) {
+            prev.covered += current.stat.covered;
+            prev.total += current.stat.total;
+
+            return prev;
+        },
+        {total: 0, covered: 0}
+    );
+
+    return q.resolve({
+        reports: reports,
+        covered: stat.covered,
+        total: stat.total,
+        percent: Math.round(stat.covered / stat.total * 100)
+    });
+}
+
+function writeIndex(stats, covDir) {
     return qfs.read(path.join(__dirname, 'coverage-index.hbs'))
         .then(function(tmpl) {
-            var covered = reports.reduce(function(prev, current) {
-                    return prev + current.stat.covered;
-                }, 0),
-                total = reports.reduce(function(prev, current) {
-                    return prev + current.stat.total;
-                }, 0);
-
             return qfs.write(
                 path.join(covDir, 'index.html'),
-                hb.compile(tmpl)({
-                    reports: reports,
-                    total: total,
-                    covered: covered,
-                    percent: Math.round(covered / total * 100)
-                }));
+                hb.compile(tmpl)(stats));
         });
+}
+
+function writeStatsJson(stats, covDir) {
+    return qfs.write(
+        path.join(covDir, 'coverage.json'),
+        JSON.stringify(
+        {
+            files: stats.reports,
+            total: stats.total,
+            covered: stats.covered,
+            percent: stats.percent
+        }, null, 4));
 }
 
 function copyResources(covDir) {


### PR DESCRIPTION
JSON is written to `[projectRoot]/gemini-coverage/coverage.json`.
Format is as follows:

``` js
{
    "total": 22,
    "covered": 11,
    "percent": 50,
    "files": [
        {
            "source": "common.blocks/button/__icon/button__icon.css",
            "report": "common.blocks_button___icon_button__icon.css.html",
            "stat": {
                "total": 1,
                "covered": 0,
                "percent": 0
            }
        },
        ...
    ]
}
```
