### PR TITLE
Follow symlinks when resolving CSS paths

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -2,6 +2,7 @@
 
 var inherit = require('inherit'),
     path = require('path'),
+    fs = require('fs'),
     url = require('url'),
     q = require('q'),
     qfs = require('q-io/fs'),
@@ -187,9 +188,15 @@ module.exports = inherit({
 
         var sourceStart = getPosition(rule.position.start, opts.file, opts.map),
             sourceEnd = getPosition(rule.position.end, opts.file, opts.map),
-            src = sourceStart.source?
-                path.relative(this.config.sourceRoot, path.resolve(opts.docDir, sourceStart.source)) :
-                opts.file.replace(this.config.rootUrl, '').replace(/^\//, '');
+            // Synchronous realpath() is used because of original method is totally synchronous and recursive,
+            // while the order of recursive calls is important. Making the code being asynchronous won't make
+            // much benefit considering only one async call can be executed to guarantee the calling order.
+            src = path.relative(
+                this.config.sourceRoot,
+                fs.realpathSync(sourceStart.source?
+                    path.resolve(opts.docDir, sourceStart.source) :
+                    opts.file.replace(this.config.rootUrl, '').replace(/^\//, ''))
+            );
 
         var blocks = (opts.out[src] = opts.out[src] || {}),
             posKey = sourceStart.line + ':' + sourceStart.column + ':' + sourceEnd.line + ':' + sourceEnd.column,


### PR DESCRIPTION
Synchronous `realpath()` is used because of original method is totally synchronous and recursive, while the order of recursive calls is important. Making the code being asynchronous won't make much benefit considering only one async call can be executed to guarantee the calling order.
