### PR TITLE
Error message when crop region exceeds screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Dev
+
+* Detailed error message when capture region exceeds screenshot
+area. Such error also will now fail only single state instead of
+a whole testing process (@SevInf).
+
 ## 0.9.1 - 2014-10-23
 
 * Ignore ``@keyframes` at-rule while collecting coverage (@scf2k).

--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -70,12 +70,28 @@ module.exports = inherit({
         }
 
         if (location.top + size.height > imageSize.height) {
+            // This case is handled specially because of Opera 12 browser.
+            // Problem, described in error message occurs there much more often then
+            // for other browsers and has different workaround
             return q.reject(new StateError(util.format(
                 'Failed to capture the element because it is positioned outside of the captured body. ' +
                 'Most probably you are trying to capture an absolute positioned element which does not make body ' +
                 'height to expand. To fix this place a tall enough <div> on the page to make body expand.\n' +
                 'Element position: %s, %s; size: %s, %s. Page screenshot size: %s, %s. ',
                 location.left, location.top, size.width, size.height, imageSize.width, imageSize.height)));
+        }
+
+        if (isOutsideOfImage(location, size, imageSize)) {
+            return q.reject(new StateError(
+                'Can not capture specified region of the page\n' +
+                'The size of a region is larger then image, captured by browser\n' +
+                'Check that elements:\n' +
+                ' - does not overflows the body element\n' +
+                ' - does not overflows browser viewport\n ' +
+                'Alternatively, you can increase browser window size using\n' +
+                '"setWindowSize" or "windowSize" option in config file.'
+
+            ));
         }
 
         return {
@@ -87,3 +103,7 @@ module.exports = inherit({
     }
 
 });
+
+function isOutsideOfImage(location, size, imageSize) {
+    return location.top < 0 || location.left < 0 || location.left + size.width > imageSize.width;
+}


### PR DESCRIPTION
Previously, gemini would simply fail in this case with
'Bad arguments' error. Now extensive message will be shown
with a list of possible workarounds. Only one state will fail
in this case without interrupting the whole testing process.

@arikon @scf2k @j0tunn 
