### PR TITLE
Fix box-shadow parsing for IE9

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -126,7 +126,7 @@
     }
 
     function parseBoxShadow(value) {
-        var regex = /([-+]?\d*\.?\d+)px (?:([-+]?\d*\.?\d+)px)? (?:([-+]?\d*\.?\d+)px)? (?:([-+]?\d*\.?\d+)px)?/,
+        var regex = /[-+]?\d*\.?\d+px/g,
             values = value.split(','),
             results = [],
             match;
@@ -135,10 +135,10 @@
             value = values[value];
             if ((match = value.match(regex))) {
                 results.push({
-                    offsetX: +match[1],
-                    offsetY: +match[2] || 0,
-                    blurRadius: +match[3] || 0,
-                    spreadRadius: +match[4] || 0,
+                    offsetX: parseFloat(match[0]),
+                    offsetY: parseFloat(match[1]) || 0,
+                    blurRadius: parseFloat(match[2]) || 0,
+                    spreadRadius: parseFloat(match[3]) || 0,
                     inset: value.indexOf('inset') !== -1
                 });
             }


### PR DESCRIPTION
In IE `window.getComputedStyle().boxShadow` value has different order of color, dimensions and inset parts than in chrome/firefox. Also dimensions count can be less than 4 (as it was specified in the source css). So regexp is changed a little and shadow string is splat by a comma. Every splat part is matched against regexp to extract dimensions. Inset is checked by just using `indexOf()` on every splat part.
