### PR TITLE
Add `sendFile` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Dev
 
+* Add `sendFile` action which now should be used instead of
+  `sendKeys` to set a file to `input[type=file]` elements (@SevInf).
 * Fail only single test if reference image is not found (@SevInf).
 
 ## 0.9.3 - 2014-11-07

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -220,5 +220,7 @@ Full list of special keys (there are shortcuts for commonly used keys):
 `NUMPAD8`, `NUMPAD9`, `MULTIPLY`, `ADD`, `SEPARATOR`, `SUBTRACT`, `DECIMAL`, `DIVIDE`, `F1`, `F2`, `F3`, `F4`, `F5`,
 `F6`, `F7`, `F8`, `F9`, `F10`, `F11`, `F12`, `COMMAND` ⇔ `META`, `ZENKAKU_HANKAKU`.
 
+* `sendFile(element, path)` - send file to the specified `input[type=file]` element. `path` must exist at
+  local system (the one which `gemini` is executed on).
 * `focus(element)` - set a focus to a specified element.
 * `setWindowSize(width, height)` - change browser window dimensions.

--- a/doc/tests.ru.md
+++ b/doc/tests.ru.md
@@ -188,5 +188,7 @@
 `NUMPAD8`, `NUMPAD9`, `MULTIPLY`, `ADD`, `SEPARATOR`, `SUBTRACT`, `DECIMAL`, `DIVIDE`, `F1`, `F2`, `F3`, `F4`, `F5`,
 `F6`, `F7`, `F8`, `F9`, `F10`, `F11`, `F12`, `COMMAND` ⇔ `META`, `ZENKAKU_HANKAKU`.
 
+* `sendFile(element, path)` - выбор файла в заданном элементе `input[type=file]`. `path` должен существовать 
+  в локальной системе (там же, где запущен `gemini`).
 * `focus(element)` - устанавливает фокус на указанный элемент.
 * `setWindowSize(width, height)` - устанавливает размера окна браузера.

--- a/lib/browser/actions.js
+++ b/lib/browser/actions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var q = require('q'),
+    fs = require('q-io/fs'),
     inherit = require('inherit'),
     promiseUtil = require('../promise-util'),
     suiteUtil = require('../suite-util'),
@@ -229,6 +230,30 @@ module.exports = inherit({
 
         this._pushAction(this.sendKeys, action);
 
+        return this;
+    },
+
+    sendFile: function(element, path) {
+        var _this = this;
+        if (typeof path !== 'string') {
+            throw new TypeError('path must be string');
+        }
+        if (isInvalidElement(element)) {
+            throw new TypeError('.sendFile() must receive valid element or CSS selector');
+        }
+
+        this._pushAction(this.sendFile, function sendFile() {
+            return fs.isFile(path)
+                .then(function(isFile) {
+                    if (!isFile) {
+                        return q.reject(new StateError(path + ' should be existing file'));
+                    }
+                    return _this._findElement(element);
+                })
+                .then(function(element) {
+                    return element.sendKeys(path);
+                });
+        });
         return this;
     },
 


### PR DESCRIPTION
It works better then `sendKeys` for `input[type=file]` elements.
Internally, it uses `element.sendKeys` instead of `driver.type(element)`
which can upload local file to the server.

/сс @scf2k @j0tunn 
