### PR TITLE
Don't catch all exceptions in coverage script

### DIFF
--- a/lib/browser/client-scripts/gemini.coverage.js
+++ b/lib/browser/client-scripts/gemini.coverage.js
@@ -7,31 +7,24 @@ var util = require('./util'),
 exports.collectCoverage = function collectCoverage(rect) {
     var coverage = {},
         sheets = document.styleSheets;
-    try {
-        for (var i = 0; i < sheets.length; i++) {
-            var href = sheets[i].href,
-                rules = getRules(sheets[i]);
+    for (var i = 0; i < sheets.length; i++) {
+        var href = sheets[i].href,
+            rules = getRules(sheets[i]);
 
-            if (rules.ignored) {
-                coverage[href] = rules;
-                continue;
-            }
-            var ctx = {
-                // media rule counter
-                // coverage for media rules is stored by its index within stylesheet
-                media: -1,
-                href: href,
-                coverage: coverage
-            };
-            for (var r = 0; r < rules.length; r++) {
-                coverageForRule(rules[r], rect, ctx);
-            }
+        if (rules.ignored) {
+            coverage[href] = rules;
+            continue;
         }
-    } catch (e) {
-        return {
-            error: 'JS',
-            message: e.stack || e.message
+        var ctx = {
+            // media rule counter
+            // coverage for media rules is stored by its index within stylesheet
+            media: -1,
+            href: href,
+            coverage: coverage
         };
+        for (var r = 0; r < rules.length; r++) {
+            coverageForRule(rules[r], rect, ctx);
+        }
     }
 
     return coverage;


### PR DESCRIPTION
Replacing it with return value causes coverage processing to crash
with completely undescriptive error.
Errors will be caught by prepareScreenshot anyway, so there is really
no need to do it collectCoverage anyway.

/cc @scf2k @cody0