### PR TITLE
Fix client bridge script injection

### DIFF
--- a/lib/browser/client-bridge.js
+++ b/lib/browser/client-bridge.js
@@ -69,14 +69,14 @@ ClientBridge.prototype._clientMethodCommand = function(name, args) {
  */
 ClientBridge.prototype._guardClientCall = function(call) {
     return util.format(
-        'typeof __gemini !== "undefined"? %s : {error: "%s"})',
+        'typeof __gemini !== "undefined"? %s : {error: "%s"}',
         call,
         NO_CLIENT_FUNC
     );
 };
 
 ClientBridge.prototype._inject = function() {
-    return this._browser.evalScript(this._script);
+    return this._browser.injectScript(this._script);
 };
 
 module.exports = ClientBridge;

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -136,6 +136,10 @@ var Browser = inherit({
         return this._browser.get(url);
     },
 
+    injectScript: function(script) {
+        return this._browser.execute(script);
+    },
+
     evalScript: function(script) {
         /*jshint evil:true*/
         return this._browser.eval(script);

--- a/test/functional/client-bridge.test.js
+++ b/test/functional/client-bridge.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var ClientBridge = require('../../lib/browser/client-bridge'),
+    assert = require('chai').assert,
+    eachSupportedBrowser = require('./util').eachSupportedBrowser,
+
+    TEST_SCRIPT = 'window.__gemini = {}; window.__gemini.add2 = function(x) { return x + 2; }';
+
+describe('ClientBridge', function() {
+    eachSupportedBrowser(function() {
+        beforeEach(function() {
+            this.timeout(30000);
+            this.bridge = new ClientBridge(this.browser, TEST_SCRIPT);
+            return this.browser.initSession();
+        });
+
+        afterEach(function() {
+            this.timeout(20000);
+            return this.browser.quit();
+        });
+
+        it('should succesfully perform client method call', function() {
+            this.timeout(20000);
+            return assert.becomes(this.bridge.call('add2', [1]), 3);
+        });
+    });
+});


### PR DESCRIPTION
0.12.1 completely broke the tool by incorrect call to the client
scripts. This commit fixes all the problems and adds functional test
for the bridge.