### PR TITLE
Sizzle: work with selectors ending with space

### DIFF
--- a/lib/browser/client-scripts/query.sizzle.js
+++ b/lib/browser/client-scripts/query.sizzle.js
@@ -3,7 +3,7 @@
 var Sizzle = require('sizzle');
 
 exports.first = function(selector) {
-    var elems = Sizzle(selector + ':first');
+    var elems = Sizzle(selector.trim() + ':first');
     return elems.length > 0? elems[0] : null;
 };
 


### PR DESCRIPTION
When using Sizzle `:first` selector is added to user-passed selector
to emulate `querySelector`.
If selector string ends with space, incorrect selector was formed and
wrong element was used.
Fixed by trimming the selector string.

