### PR TITLE
Fix calibration in chrome 43+

### DIFF
--- a/lib/browser/client-scripts/gemini.calibrate.js
+++ b/lib/browser/client-scripts/gemini.calibrate.js
@@ -12,17 +12,6 @@
         return !/MSIE 8\.0/.test(navigator.userAgent);
     }
 
-    function createRedStripe(side) {
-        var div = document.createElement('div');
-        div.style.position = 'absolute';
-        div.style.width = '1px';
-        div.style.backgroundColor = '#ff0000';
-        div.style.height = '100%';
-        div.style.top = '0';
-        div.style[side] = '3px';
-        document.body.appendChild(div);
-    }
-
     function createPattern() {
         var bodyStyle = document.body.style;
         bodyStyle.margin = 0;
@@ -31,11 +20,17 @@
         if (needsResetBorder()) {
             bodyStyle.border = 0;
         }
-        bodyStyle.backgroundColor = '#00ff00';
-        bodyStyle.width = '100%';
-        bodyStyle.height = '100%';
-        createRedStripe('left');
-        createRedStripe('right');
+
+        var img = document.createElement('div');
+        img.style.width = '4px';
+        img.style.height = '1px';
+        img.style.margin = '0';
+        img.style.padding = '0';
+
+        // 1px high image with pattern: (green, green, green, red)
+        img.style.background = 'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAABCAIAAAB2XpiaAAAAD0lEQVQIW2Ng+M8AQUACABryA/01utvkAAAAAElFTkSuQmCC)';
+
+        document.body.appendChild(img);
     }
 
     function getBrowserFeatures() {


### PR DESCRIPTION
Chrome 43 changed rendering method and due to antialising calibration
script no longer produces expected result. Fixed by using PNG image
instead of creating expected pattern with DOM elements.