### PR TITLE
Возвращать понятную ошибку, если селектор соответствует скрытой области

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -86,7 +86,12 @@ function getCaptureRect(selectors) {
             rect = rect? rect.merge(elementRect) : elementRect;
         }
     }
-    return rect && rect.round();
+
+    return rect? rect.round() : {
+        error: 'HIDDEN',
+        message: 'Area with css selector : ' + selectors + ' is hidden',
+        selector: selectors
+    };
 }
 
 function findIgnoreAreas(selectors) {


### PR DESCRIPTION
Если указанному селектору соответствует скрытая область ([см. здесь](https://github.com/gemini-testing/gemini/blob/0b11b40c6205dbeb747fac3fbb0f283cbb31ef60/lib/browser/client-scripts/gemini.js#L109)), клиентская часть `gemini` возвращает мало понятную ошибку.
По-моему, лучше делать так.