### PR TITLE
Fix coverage problems

### DIFF
--- a/lib/browser/client-scripts/gemini.coverage.js
+++ b/lib/browser/client-scripts/gemini.coverage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('./util'),
+    coverageLevel = require('../../coverage-level'),
     rect = require('./rect'),
     query = require('./query');
 
@@ -66,10 +67,9 @@ function coverageForRule(rule, area, ctx) {
     }
 
     util.each(rule.selectorText.split(','), function(selector) {
-        var within,
-            matches = query.all(selector);
-
         selector = selector.trim();
+        var coverage = coverageLevel.NONE,
+            matches = query.all(selector);
 
         var re = /:{1,2}(?:after|before|first-letter|first-line|selection)(:{1,2}\w+)?$/;
         // if selector contains pseudo-elements cut it off and try to find element without it
@@ -79,39 +79,26 @@ function coverageForRule(rule, area, ctx) {
 
         if (matches.length > 0) {
             for (var match = 0; match < matches.length; match++) {
-                var w = elemWithinArea(matches[match], area);
-                if (within === undefined) {
-                    within = w;
-                }
-                if (within) {
-                    break;
-                }
-                if (w !== undefined) {
-                    within = w;
-                }
+                var newCoverage = coverageForElem(matches[match], area);
+                coverage = coverageLevel.merge(coverage, newCoverage);
             }
         }
 
-        var byfile = ctx.coverage[ctx.href] = ctx.coverage[ctx.href] || {};
+        var byURL = ctx.coverage[ctx.href] = ctx.coverage[ctx.href] || {};
         if (rule.parentRule && rule.parentRule.conditionText) {
             selector = '?' + ctx.media + ':' + selector;
         }
-        if (within !== undefined && (!byfile[selector] || !byfile[selector].within)) {
-            byfile[selector] = {
-                within: within
-            };
-        }
+
+        byURL[selector] = coverageLevel.merge(byURL[selector], coverage);
     });
 }
 
-/**
- * returns undefined when not within, false when overlaps, true when within
- */
-function elemWithinArea(elem, captureRect) {
+function coverageForElem(elem, captureRect) {
     var elemRect = rect.getAbsoluteClientRect(elem);
     if (captureRect.rectInside(elemRect)) {
-        return true;
-    } else if (captureRect.rectIntersects(captureRect)) {
-        return false;
+        return coverageLevel.FULL;
+    } else if (captureRect.rectIntersects(elemRect)) {
+        return coverageLevel.PARTIAL;
     }
+    return coverageLevel.NONE;
 }

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -174,7 +174,7 @@ var Browser = inherit({
                 basedir: path.join(__dirname, 'client-scripts')
             });
 
-        if (!this.config.coverage) {
+        if (!this.config.system.coverage.enabled) {
             script.exclude('./gemini.coverage');
         }
 

--- a/lib/config/browser-config.js
+++ b/lib/config/browser-config.js
@@ -3,8 +3,9 @@
 var path = require('path'),
     _ = require('lodash');
 
-function BrowserConfig(id, browserOptions) {
+function BrowserConfig(id, systemOptions, browserOptions) {
     this.id = id;
+    this.system = systemOptions;
     _.extend(this, browserOptions);
 }
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -26,12 +26,18 @@ function Config(configData) {
 }
 
 Config.prototype.forBrowser = function(id) {
-    return new BrowserConfig(id, this._browsers[id]);
+    return new BrowserConfig(id, this.system, this._browsers[id]);
 };
 
 Config.prototype.getBrowserIds = function() {
     return Object.keys(this._browsers);
 };
+
+Object.defineProperty(Config.prototype, 'coverageEnabled', {
+    get: function() {
+        return this.system.coverage.enabled;
+    }
+});
 
 function readConfigData(filePath) {
     var configData = readYAMLFile(filePath),

--- a/lib/coverage-level.js
+++ b/lib/coverage-level.js
@@ -1,0 +1,17 @@
+'use strict';
+exports.FULL = 'full';
+exports.PARTIAL = 'partial';
+exports.NONE = 'none';
+
+exports.merge = function(oldValue, newValue) {
+    oldValue = oldValue || exports.NONE;
+    if (oldValue === exports.FULL || newValue === exports.FULL) {
+        return exports.FULL;
+    }
+
+    if (oldValue === exports.PARTIAL || newValue === exports.PARTIAL) {
+        return exports.PARTIAL;
+    }
+
+    return exports.NONE;
+};

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var inherit = require('inherit'),
+    _ = require('lodash'),
     path = require('path'),
     fs = require('fs'),
     url = require('url'),
@@ -11,43 +12,49 @@ var inherit = require('inherit'),
     css = require('css'),
     minimatch = require('minimatch'),
     coverage = require('gemini-coverage').api,
+    coverageLevel = require('./coverage-level'),
 
     SourceMapConsumer = require('source-map').SourceMapConsumer;
 
 module.exports = inherit({
     __constructor: function(config) {
         this.config = config;
-        this.stats = [];
-        this.byfile = {};
+        this.byURL = {};
         this.covDir = path.resolve(this.config.system.projectRoot, 'gemini-coverage');
         this.out = {};
+        this._warned = {};
     },
 
-    addStats: function(stats) {
-        this.stats.push(stats);
+    addStatsForBrowser: function(stats, browser) {
+        _.each(stats, function(coverage, url) {
+            if (coverage.ignored) {
+                this._warnInnacurate(url, coverage.message);
+                return;
+            }
+            this.byURL[url] = this.byURL[url] || {
+                sourceFile: this._urlToFilePath(url, browser.config.rootUrl),
+                coverage: {}
+            };
+            _.assign(this.byURL[url].coverage, coverage, coverageLevel.merge);
+        }, this);
+    },
+
+    _warnInnacurate: function(url, message) {
+        if (this._warned[url]) {
+            return;
+        }
+        console.warn(chalk.yellow('WARNING:'), chalk.blue(url), 'may have inaccurate coverage report');
+        console.warn(message);
+        this._warned[url] = true;
+    },
+
+    _urlToFilePath: function(url, rootUrl) {
+        var relPath = url.replace(rootUrl, '').replace(/^\//, '');
+        return path.resolve(this.config.system.sourceRoot, relPath);
     },
 
     processStats: function() {
-        var _this = this,
-            warned = {};
-        this.stats.forEach(function(stat) {
-            Object.keys(stat).forEach(function(file) {
-                var fileStat = stat[file];
-                if (fileStat.ignored && !warned[file]) {
-                    console.warn(chalk.yellow('WARNING:'), chalk.blue(file), 'may have inaccurate coverage report');
-                    console.warn(fileStat.message);
-                    warned[file] = true;
-                    return;
-                }
-                var rules = _this.byfile[file] = _this.byfile[file] || {};
-
-                Object.keys(fileStat).forEach(function(rule) {
-                    if (!rules[rule]) {
-                        rules[rule] = stat[file][rule];
-                    }
-                });
-            });
-        });
+        var _this = this;
 
         return qfs.makeDirectory(this.covDir)
             .fail(function(err) {
@@ -57,8 +64,8 @@ module.exports = inherit({
                 }
             })
             .then(function() {
-                return q.all(Object.keys(_this.byfile).map(function(file) {
-                    return _this.processFile(file);
+                return q.all(Object.keys(_this.byURL).map(function(url) {
+                    return _this.processCSS(url);
                 }))
                 .then(function() {
                     return _this.prepareOutputStats();
@@ -67,13 +74,13 @@ module.exports = inherit({
                     return _this.writeStatsJson(data);
                 })
                 .then(function(data) {
-                    if (_this.config.coverageNoHtml) {
+                    if (!_this.config.system.coverage.html) {
                         return;
                     }
 
                     return coverage.gen({
-                        sourceRoot: _this.config.sourceRoot,
-                        destDir: path.join(_this.config.projectRoot, 'gemini-coverage')
+                        sourceRoot: _this.config.system.sourceRoot,
+                        destDir: path.join(_this.config.system.projectRoot, 'gemini-coverage')
                     }, {
                         coverage: data
                     });
@@ -81,36 +88,34 @@ module.exports = inherit({
             });
     },
 
-    processFile: function(file, tmpl) {
+    processCSS: function(url) {
         var _this = this,
-            cssRelPath = file.replace(this.config.rootUrl, '').replace(/^\//, ''),
-            cssPath = path.resolve(this.config.sourceRoot, cssRelPath);
+            cssPath = this.byURL[url].sourceFile,
+            cssRelPath = path.relative(this.config.system.sourceRoot, cssPath);
 
         if (this.fileExcluded(cssRelPath)) {
             return;
         }
 
-        return http.read({url: file})
+        return readUrlOrFile(url, cssPath)
             .then(function(content) {
-                var ast = css.parse(content += '');
+                var ast = css.parse(content);
                 return q.all([
                     ast,
                     content,
-                    _this.getSourceMap(ast, cssPath, file)
+                    _this.getSourceMap(ast, cssPath, url)
                 ]);
             })
             .spread(function(ast, fileContent, map) {
-                fileContent += '';
-                var lines = fileContent.split(/\r?\n/g),
-                    ctx = {media: 0},
+                var ctx = {media: 0},
                     out = _this.out;
 
                 for (var r = 0; r < ast.stylesheet.rules.length; r++) {
                     _this.processRule(
                         ast.stylesheet.rules[r],
                         {
-                            lines: lines,
-                            file: file,
+                            url: url,
+                            filePath: cssPath,
                             out: out,
                             map: map,
                             docDir: path.dirname(cssPath)
@@ -162,8 +167,7 @@ module.exports = inherit({
                     this.processRule(
                         childRule,
                         {
-                            lines: opts.lines,
-                            file: opts.file,
+                            url: opts.url,
                             out: opts.out,
                             group: true,
                             map: opts.map,
@@ -178,72 +182,54 @@ module.exports = inherit({
             return;
         }
 
-        var cls = 'none';
-        for (var sel = 0; sel < rule.selectors.length; sel++) {
-            var key = rule.selectors[sel];
+        var ruleCoverage = _.reduce(rule.selectors, function(coverage, selector) {
+            var key = selector;
             if (opts.group) {
                 key = '?' + ctx.media + ':' + key;
             }
+            return coverageLevel.merge(coverage, this.byURL[opts.url].coverage[key]);
+        }, coverageLevel.NONE, this);
 
-            var selector = this.byfile[opts.file][key];
-            if (selector) {
-                cls = 'partial';
-                if (selector.within) {
-                    cls = 'covered';
-                }
-                break;
-            }
-        }
-
-        var sourceStart = getPosition(rule.position.start, opts.file, opts.map),
-            sourceEnd = getPosition(rule.position.end, opts.file, opts.map),
+        var sourceStart = getPosition(rule.position.start, opts.url, opts.map),
+            sourceEnd = getPosition(rule.position.end, opts.url, opts.map),
             // Synchronous realpath() is used because of original method is totally synchronous and recursive,
             // while the order of recursive calls is important. Making the code being asynchronous won't make
             // much benefit considering only one async call can be executed to guarantee the calling order.
             src = path.relative(
-                this.config.sourceRoot,
+                this.config.system.sourceRoot,
                 fs.realpathSync(sourceStart.source?
                     path.resolve(opts.docDir, sourceStart.source) :
-                    opts.file.replace(this.config.rootUrl, '').replace(/^\//, ''))
-            );
+                    opts.filePath)
+            ),
+            block = this._getSourceBlock(src, sourceStart, sourceEnd);
 
-        var blocks = (opts.out[src] = opts.out[src] || {}),
-            posKey = sourceStart.line + ':' + sourceStart.column + ':' + sourceEnd.line + ':' + sourceEnd.column,
-            block = blocks[posKey];
+        block.coverage = coverageLevel.merge(block.coverage, ruleCoverage);
+    },
 
-        if (block) {
-            var types = {
-                'none': 0,
-                'partial': 1,
-                'covered': 2
-            };
+    _getSourceBlock: function(source, start, end) {
+        var blocks = (this.out[source] = this.out[source] || {}),
+            key = [start.line, start.column, end.line, end.column].join(':');
 
-            if (types[cls] > types[block.type]) {
-                block.type = cls;
-            }
-        } else {
-            blocks[posKey] = {
+        if (!blocks[key]) {
+            blocks[key] = {
                 start: {
-                    line: sourceStart.line,
-                    column: sourceStart.column
+                    line: start.line,
+                    column: start.column
                 },
                 end: {
-                    line: sourceEnd.line,
-                    column: sourceEnd.column
+                    line: end.line,
+                    column: end.column
                 },
-                type: cls
+                coverage: coverageLevel.NONE
             };
         }
+        return blocks[key];
     },
 
     fileExcluded: function(path) {
-        for (var i = 0; i < this.config.coverageExclude.length; i++) {
-            if (minimatch(path, this.config.coverageExclude[i], {matchBase: true})) {
-                return true;
-            }
-        }
-
-        return false;
+        return this.config.system.coverage.exclude.some(function(excludePattern) {
+            return minimatch(path, excludePattern, {matchBase: true});
+        });
     },
 
     writeStatsJson: function(data) {
@@ -266,10 +252,14 @@ module.exports = inherit({
                     var covered = 0,
                         blocks = Object.keys(_this.out[file]).map(function(blockKey) {
                             var block = _this.out[file][blockKey];
-                            if (block.type === 'covered') {
+                            if (block.coverage === 'full') {
                                 covered++;
                             }
-                            return block;
+                            return {
+                                start: block.start,
+                                end: block.end,
+                                type: coverageToType(block.coverage)
+                            };
                         });
 
                     stat.covered += covered;
@@ -323,4 +313,15 @@ function readUrlOrFile(url, file) {
         .then(function(content) {
             return content + '';
         });
+}
+
+function coverageToType(coverage) {
+    switch (coverage) {
+        case coverageLevel.FULL:
+            return 'covered';
+        case coverageLevel.PARTIAL:
+            return 'partial';
+        case coverageLevel.NONE:
+            return 'none';
+    }
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -49,7 +49,7 @@ module.exports = inherit(EventEmitter, {
             return _this._runBrowsers(suites);
         })
         .then(function() {
-            if (_this.config.coverage) {
+            if (_this.config.coverageEnabled) {
                 return _this.coverage.processStats();
             }
         })
@@ -164,10 +164,10 @@ module.exports = inherit(EventEmitter, {
 
         _this.emit(RunnerEvents.BEGIN_STATE, eventData);
 
-        return session.capture(state, {coverage: this.config.coverage})
+        return session.capture(state, {coverage: this.config.coverageEnabled})
             .then(function(data) {
-                if (_this.config.coverage) {
-                    _this.coverage.addStats(data.coverage);
+                if (_this.config.coverageEnabled) {
+                    _this.coverage.addStatsForBrowser(data.coverage, session.browser);
                 }
                 return q(_this._processCapture({
                     suite: suite,

--- a/test/browser-config.test.js
+++ b/test/browser-config.test.js
@@ -5,7 +5,7 @@ var BrowserConfig = require('../lib/config/browser-config'),
 
 describe('BrowserConfig', function() {
     function createConfig(options) {
-        return new BrowserConfig('id', options);
+        return new BrowserConfig('id', {}, options);
     }
 
     describe('getAbsoluteUrl', function() {
@@ -49,7 +49,7 @@ describe('BrowserConfig', function() {
 
     describe('getScreenshotPath', function() {
         it('should return path to the image', function() {
-            var config = new BrowserConfig('browser', {
+            var config = new BrowserConfig('browser', {}, {
                     screenshotsDir: '/screens'
                 }),
                 suite = createSuite('suite'),

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -47,15 +47,12 @@ describe('browser', function() {
                 setWindowSize: sinon.stub().returns(q({}))
             };
 
-            this.config = {
-                calibrate: false
-            };
             this.sinon.stub(wd, 'promiseRemote').returns(this.wd);
             this.calibrator = sinon.createStubInstance(Calibrator);
             this.browser = makeBrowser({
                 browserName: 'browser',
                 version: '1.0'
-            }, this.config);
+            }, {calibrate: false});
 
             this.launchBrowser = function() {
                 return this.browser.launch(this.calibrator);
@@ -74,7 +71,7 @@ describe('browser', function() {
 
         it('should set http options for browser instance', function() {
             var _this = this;
-            this.config.httpTimeout = 100;
+            this.browser.config.httpTimeout = 100;
             return this.browser.launch(this.calibrator).then(function() {
                 assert.calledWith(_this.wd.configureHttp, {
                     timeout: 100,
@@ -85,12 +82,8 @@ describe('browser', function() {
 
         it('should calibrate if config.calibrate=true', function() {
             var _this = this;
-            this.config.calibrate = true;
-            this.browser = makeBrowser({
-                browserName: 'browser',
-                version: '1.0'
-            }, this.config);
 
+            this.browser.config.calibrate = true;
             this.calibrator.calibrate.returns(q());
             return this.browser.launch(this.calibrator).then(function() {
                 assert.calledWith(_this.calibrator.calibrate);
@@ -99,7 +92,7 @@ describe('browser', function() {
 
         it('should not call calibrate() when config.calibrate=false', function() {
             var _this = this;
-            this.config.calibrate = false;
+            this.browser.config.calibrate = false;
             return this.browser.launch(this.calibrator).then(function() {
                 assert.notCalled(_this.calibrator.calibrate);
             });
@@ -107,7 +100,7 @@ describe('browser', function() {
 
         describe('with windowSize option', function() {
             beforeEach(function() {
-                this.config.windowSize = {width: 1024, height: 768};
+                this.browser.config.windowSize = {width: 1024, height: 768};
             });
 
             it('should set window size', function() {
@@ -253,13 +246,25 @@ describe('browser', function() {
 
     describe('buildScripts', function() {
         it('should include coverage script when coverage is on', function() {
-            var browser = makeBrowser({browserName: 'browser', version: '1.0'}, {coverage: true}),
+            var browser = makeBrowser({browserName: 'browser', version: '1.0'}, {
+                    system: {
+                        coverage: {
+                            enabled: true
+                        }
+                    }
+                }),
                 scripts = browser.buildScripts();
             return assert.eventually.include(scripts, 'exports.collectCoverage');
         });
 
         it('should not include coverage script when coverage is off', function() {
-            var browser = makeBrowser({browserName: 'browser', version: '1.0'}, {coverage: false}),
+            var browser = makeBrowser({browserName: 'browser', version: '1.0'}, {
+                    system: {
+                        coverage: {
+                            enabled: false
+                        }
+                    }
+                }),
                 scripts = browser.buildScripts();
             return assert.eventually.notInclude(scripts, 'exports.collectCoverage');
         });

--- a/test/coverage-level.test.js
+++ b/test/coverage-level.test.js
@@ -1,0 +1,38 @@
+'use strict';
+var assert = require('assert'),
+    level = require('../lib/coverage-level');
+describe('coverage level', function() {
+    describe('merge', function() {
+        it('NONE + NONE should equal NONE', function() {
+            assert.equal(level.merge(level.NONE, level.NONE), level.NONE);
+        });
+
+        it('NONE + PARTIAL should equal PARTIAL', function() {
+            assert.equal(level.merge(level.NONE, level.PARTIAL), level.PARTIAL);
+        });
+
+        it('PARTIAL + NONE should equal PARTIAL', function() {
+            assert.equal(level.merge(level.PARTIAL, level.NONE), level.PARTIAL);
+        });
+
+        it('NONE + FULL should equal FULL', function() {
+            assert.equal(level.merge(level.NONE, level.FULL), level.FULL);
+        });
+
+        it('FULL + NONE should equal FULL', function() {
+            assert.equal(level.merge(level.FULL, level.NONE), level.FULL);
+        });
+
+        it('PARTIAL + FULL should equal FULL', function() {
+            assert.equal(level.merge(level.PARTIAL, level.FULL), level.FULL);
+        });
+
+        it('FULL + PARTIAL should equal FULL', function() {
+            assert.equal(level.merge(level.FULL, level.PARTIAL), level.FULL);
+        });
+
+        it('FULL + FULL should equal FULL', function() {
+            assert.equal(level.merge(level.FULL, level.FULL), level.FULL);
+        });
+    });
+});

--- a/test/util.js
+++ b/test/util.js
@@ -1,10 +1,15 @@
 'use strict';
-var Browser = require('../lib/browser');
+var Browser = require('../lib/browser'),
+    _ = require('lodash');
 
 function makeBrowser(capabilities, config) {
-    config = config || {};
-    config.id = config.id || 'id';
-    config.desiredCapabilities = capabilities;
+    config = _.merge({}, {
+        id: 'id',
+        desiredCapabilities: capabilities,
+        system: {
+            coverage: {}
+        }
+    }, config);
     return new Browser(config);
 }
 


### PR DESCRIPTION
This commit fixes multiple coverage problems:
1. Coverage was not working in 0.13.0-alpha completely
due to a changes in config file.
2. Partial coverage was detected incorrectly
3. Merge of coverge report from different browsers was
performed incorrectly: last value had always overriden
the previous.

Internal coverage level reporting is changed from
true/false/undefined to enum FULL, PARTIAL, NONE and merge
function is defined. This enum is shared between both client
script and gemini.