### PR TITLE
Use viewport offset if document is wider then ss

### DIFF
--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -40,7 +40,6 @@ module.exports = inherit({
                 return _this.browser.prepareScreenshot(state.captureSelectors, opts)
                     .then(function(prepareData) {
                         return _this.browser.captureFullscreenImage().then(function(image) {
-                            _this._validateImage(image, prepareData);
                             return [
                                 image,
                                 getToImageCoordsFunction(image, prepareData),
@@ -49,10 +48,13 @@ module.exports = inherit({
                         });
                     })
                     .spread(function(image, toImageCoords, prepareData) {
+                        var cropArea = toImageCoords(prepareData.captureArea);
+                        _this._validateImage(image, cropArea);
+
                         prepareData.ignoreAreas.forEach(function(area) {
                             image.clear(toImageCoords(area));
                         });
-                        return image.crop(toImageCoords(prepareData.captureArea))
+                        return image.crop(cropArea)
                             .then(function(crop) {
                                 return {
                                     image: crop,
@@ -64,16 +66,10 @@ module.exports = inherit({
             });
     },
 
-    _validateImage: function(image, prepareData) {
+    _validateImage: function(image, cropArea) {
         var imageSize = image.getSize(),
-            captureArea = prepareData.captureArea,
-            bottomBorder = captureArea.top + captureArea.height;
-
-        if (imageSize.height < prepareData.documentHeight) {
-            bottomBorder -= prepareData.viewportOffset.top;
-        }
-
-        if (bottomBorder > imageSize.height) {
+            bottom = cropArea.top + cropArea.height;
+        if (bottom > imageSize.height) {
             // This case is handled specially because of Opera 12 browser.
             // Problem, described in error message occurs there much more often then
             // for other browsers and has different workaround
@@ -82,16 +78,16 @@ module.exports = inherit({
                 'Most probably you are trying to capture an absolute positioned element which does not make body ' +
                 'height to expand. To fix this place a tall enough <div> on the page to make body expand.\n' +
                 'Element position: %s, %s; size: %s, %s. Page screenshot size: %s, %s. ',
-                captureArea.left,
-                captureArea.top,
-                captureArea.width,
-                captureArea.height,
+                cropArea.left,
+                cropArea.top,
+                cropArea.width,
+                cropArea.height,
                 imageSize.width,
                 imageSize.height
             ));
         }
 
-        if (isOutsideOfImage(prepareData, imageSize)) {
+        if (isOutsideOfImage(imageSize, cropArea)) {
             throw new StateError(
                 'Can not capture specified region of the page\n' +
                 'The size of a region is larger then image, captured by browser\n' +
@@ -107,19 +103,13 @@ module.exports = inherit({
 
 });
 
-function isOutsideOfImage(data, imageSize) {
-    var area = data.captureArea,
-        scrollPos = 0;
-
-    if (imageSize.width < data.documentWidth) {
-        scrollPos = data.viewportOffset.left;
-    }
-
-    return area.top < 0 || area.left < 0 || area.left + area.width - scrollPos > imageSize.width;
+function isOutsideOfImage(imageSize, cropArea) {
+    return cropArea.top < 0 || cropArea.left < 0 || cropArea.left + cropArea.width > imageSize.width;
 }
 
 function getToImageCoordsFunction(image, prepareData) {
-    if (image.getSize().height >= prepareData.documentHeight) {
+    var imageSize = image.getSize();
+    if (imageSize.height >= prepareData.documentHeight && imageSize.width >= prepareData.documentWidth) {
         return function toImageCoords(area) {
             return area;
         };


### PR DESCRIPTION
Previous code took scrolling into account only when docment was
higher then image. This caused incorrect calculation of crop area
in case when document is wider then screenshot, but heights are
equal.