### PR TITLE
Restore debug and start work on its improvement

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -3,6 +3,7 @@
 var path = require('path'),
     util = require('util'),
     inherit = require('inherit'),
+    debug = require('debug'),
     wd = require('wd'),
     q = require('q'),
     chalk = require('chalk'),
@@ -22,31 +23,26 @@ var Browser = inherit({
         this.config = config;
         this.id = config.id;
         this._browser = wd.promiseRemote(config.gridUrl);
+        this.log = debug('gemini:browser:' + this.id);
 
-        // optional extra logging
-        if (config.debug) { //TODO:
-            this._browser.on('connection', function(code, message, error) {
-                console.log(chalk.red(' ! ' + code + ': ' + message));
-            });
-            this._browser.on('status', function(info) {
-                console.log(chalk.cyan(info));
-            });
-            this._browser.on('command', function(eventType, command, response) {
-                if (eventType === 'RESPONSE' && command === 'takeScreenshot()') {
-                    response = '<binary-data>';
-                }
-                if (typeof response !== 'string') {
-                    response = JSON.stringify(response);
-                }
-                console.log(' > ' + chalk.cyan(eventType), command, chalk.grey(response || ''));
-            });
-            this._browser.on('http', function(meth, path, data) {
-                if (typeof data !== 'string') {
-                    data = JSON.stringify(data);
-                }
-                console.log(' > ' + chalk.magenta(meth), path, chalk.grey(data || ''));
-            });
-        }
+        var wdLog = debug('gemini:webdriver:' + this.id);
+
+        this._browser.on('connection', function(code, message, error) {
+            wdLog('Error: code %d, %s', code, message);
+        });
+
+        this._browser.on('status', function(info) {
+            wdLog(info);
+        });
+        this._browser.on('command', function(eventType, command, response) {
+            if (eventType === 'RESPONSE' && command === 'takeScreenshot()') {
+                response = '<binary-data>';
+            }
+            if (typeof response !== 'string') {
+                response = JSON.stringify(response);
+            }
+            wdLog(chalk.cyan(eventType), command, chalk.grey(response || ''));
+        });
     },
 
     launch: function(calibrator) {
@@ -105,6 +101,9 @@ var Browser = inherit({
             })
             .then(function() {
                 return _this._browser.init(_this.capabilities);
+            })
+            .spread(function(sessionId, actualCapabilities) {
+                _this.log('new session', sessionId);
             });
     },
 

--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -1,5 +1,6 @@
 'use strict';
 var QEmitter = require('qemitter'),
+    debug = require('debug'),
     util = require('util'),
     path = require('path'),
 
@@ -34,6 +35,9 @@ function Gemini(config, overrides) {
     QEmitter.call(this);
     config = config || DEFAULT_CFG_NAME;
     this.config = new Config(config, overrides);
+    if (this.config.system.debug) {
+        debug.enable('gemini:*');
+    }
     var _this = this;
 
     require('./plugins').load(_this, this.config);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chalk": "^0.5.1",
     "coa": "~0.4.0",
     "css": "^2.1.0",
+    "debug": "^2.2.0",
     "es6-weak-map": "^1.0.2",
     "gemini-configparser": "^0.1.0",
     "gemini-coverage": "~0.3.0",

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -44,7 +44,8 @@ describe('browser', function() {
                 init: sinon.stub().returns(q({})),
                 get: sinon.stub().returns(q({})),
                 eval: sinon.stub().returns(q('')),
-                setWindowSize: sinon.stub().returns(q({}))
+                setWindowSize: sinon.stub().returns(q({})),
+                on: sinon.stub()
             };
 
             this.sinon.stub(wd, 'promiseRemote').returns(this.wd);
@@ -131,7 +132,8 @@ describe('browser', function() {
     describe('open', function() {
         beforeEach(function() {
             this.wd = {
-                get: sinon.stub().returns(q({}))
+                get: sinon.stub().returns(q({})),
+                on: sinon.stub()
             };
 
             this.sinon.stub(wd, 'promiseRemote').returns(this.wd);
@@ -151,7 +153,8 @@ describe('browser', function() {
     describe('openRelative', function() {
         it('should open relative URL using config', function() {
             this.wd = {
-                get: sinon.stub().returns(q({}))
+                get: sinon.stub().returns(q({})),
+                on: sinon.stub()
             };
 
             this.sinon.stub(wd, 'promiseRemote').returns(this.wd);
@@ -172,7 +175,8 @@ describe('browser', function() {
         beforeEach(function() {
             this.wd = {
                 eval: sinon.stub().returns(q()),
-                moveTo: sinon.stub().returns(q())
+                moveTo: sinon.stub().returns(q()),
+                on: sinon.stub()
             };
 
             this.sinon.stub(wd, 'promiseRemote').returns(this.wd);
@@ -197,7 +201,8 @@ describe('browser', function() {
             var img = path.join(__dirname, 'functional', 'data', 'image', 'image1.png'),
                 imgData = fs.readFileSync(img),
                 stubWd = {
-                    takeScreenshot: sinon.stub().returns(q(imgData))
+                    takeScreenshot: sinon.stub().returns(q(imgData)),
+                    on: sinon.stub()
                 };
 
             this.sinon.stub(wd, 'promiseRemote').returns(stubWd);
@@ -216,7 +221,8 @@ describe('browser', function() {
                 init: sinon.stub().returns(q(imgData)),
                 configureHttp: sinon.stub().returns(q()),
                 eval: sinon.stub().returns(q('')),
-                takeScreenshot: sinon.stub().returns(q(imgData))
+                takeScreenshot: sinon.stub().returns(q(imgData)),
+                on: sinon.stub()
             };
 
             this.sinon.stub(wd, 'promiseRemote').returns(this.wd);
@@ -277,7 +283,8 @@ describe('browser', function() {
                 init: sinon.stub().returns(q({})),
                 get: sinon.stub().returns(q({})),
                 eval: sinon.stub().returns(q('')),
-                elementByCssSelector: sinon.stub().returns(q())
+                elementByCssSelector: sinon.stub().returns(q()),
+                on: sinon.stub()
             };
             this.sinon.stub(wd, 'promiseRemote').returns(this.wd);
             this.browser = makeBrowser({browserName: 'bro'}, {


### PR DESCRIPTION
Uses node-debug module. If config option is set to true, enables
all output. Altertanively, DEBUG env variable can be used. For now,
there are following logging namespaces:

- `gemini:browser:<id>` to display log for particluar browser (does not
include webdriver commands, for now shows only session id).
- `gemini:webdirver:<id>` to display webdriver logs for a browser (same
as <0.13 logs).

Wildcards can be used instead of browser id.