### PR TITLE
Perform post actions from before/after callbacks

### DIFF
--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -17,7 +17,7 @@ module.exports = inherit({
         return this.browser.id;
     },
 
-    runHook: function(hook) {
+    runHook: function(hook, suite) {
         var sequence = this.browser.createActionSequence();
 
         try {
@@ -25,7 +25,10 @@ module.exports = inherit({
         } catch (e) {
             return q.reject(new StateError('Error while executing callback', e));
         }
-        return sequence.perform().thenResolve(sequence);
+        return sequence.perform()
+            .then(function() {
+                suite.addPostActions(sequence.getPostActions());
+            });
     },
 
     capture: function(state, opts) {
@@ -34,9 +37,8 @@ module.exports = inherit({
             ignoreSelectors: state.ignoreSelectors
         });
 
-        return _this.runHook(state.callback)
+        return _this.runHook(state.callback, state.suite)
             .then(function(actions) {
-                state.suite.addPostActions(actions.getPostActions());
                 return _this.browser.prepareScreenshot(state.captureSelectors, opts)
                     .then(function(prepareData) {
                         return _this.browser.captureFullscreenImage().then(function(image) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -131,7 +131,7 @@ module.exports = inherit(EventEmitter, {
                 var session = new CaptureSession(browser);
                 return browser.open(_this.config.getAbsoluteUrl(suite.url))
                     .then(function() {
-                        return session.runHook(suite.beforeHook);
+                        return session.runHook(suite.beforeHook, suite);
                     })
                     .then(function() {
                         return promiseUtils.seqMap(suite.states, function(state) {
@@ -139,7 +139,7 @@ module.exports = inherit(EventEmitter, {
                         });
                     })
                     .then(function() {
-                        return session.runHook(suite.afterHook);
+                        return session.runHook(suite.afterHook, suite);
                     })
                     .then(function() {
                         return suite.runPostActions();


### PR DESCRIPTION
Previously, it was only performed for sate callbacks, so
window size set in before callback was not restored.

@j0tunn @unlok 