### PR TITLE
API: do not options with CLI flags and env vars

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -63,7 +63,7 @@ function runGemini(method, paths, options) {
     options = options || {};
     return q.fcall(function() {
             checkForDeperactions();
-            return new Gemini(program.config);
+            return new Gemini(program.config, {cli: true, env: true});
         })
         .then(function(gemini) {
             return gemini[method](paths, {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -9,18 +9,31 @@ var path = require('path'),
 
     parseOptions = require('./options');
 
-function Config(configData) {
-    var filePath;
+/**
+ * @param {Object|String} configData data of the config or path to file
+ * @param {Object} allowOverrides
+ * @param {Boolean} allowOverrides.env
+ * @param {Boolean} allowOverrides.cli
+ */
+function Config(configData, allowOverrides) {
+    allowOverrides = _.defaults(allowOverrides || {}, {
+        env: false,
+        cli: false
+    });
+
+    var env = allowOverrides.env? process.env : {},
+        argv = allowOverrides.cli? process.argv : [];
+
     if (_.isString(configData)) {
-        filePath = configData;
-        configData = readConfigData(filePath);
+        configData = readConfigData(configData);
     }
 
     var parsed = parseOptions({
         options: configData,
-        env: process.env,
-        argv: process.argv
+        env: env,
+        argv: argv
     });
+
     this.system = parsed.system;
     this._browsers = parsed.browsers;
 }

--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -31,13 +31,14 @@ function requireWithNoCache(moduleName) {
     return result;
 }
 
-function Gemini(config) {
+function Gemini(config, allowOverrides) {
     QEmitter.call(this);
     config = config || DEFAULT_CFG_NAME;
-    this.config = new Config(config);
+    this.config = new Config(config, allowOverrides);
     if (this.config.system.debug) {
         debug.enable('gemini:*');
     }
+
     var _this = this;
 
     require('./plugins').load(_this, this.config);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,55 @@
+'use strict';
+var Config = require('../lib/config'),
+    assert = require('chai').assert;
+
+describe('config', function() {
+    describe('overrides', function() {
+        beforeEach(function() {
+            /*jshint -W069*/
+            this.configValue = '/from/config';
+            this.envValue = '/from/env';
+            this.cliValue = '/from/cli';
+
+            process.env['gemini_system_project_root'] = this.envValue;
+
+            this.oldArgv = process.argv;
+            process.argv = this.oldArgv.concat('--system-project-root', this.cliValue);
+
+            this.getFinalConfigValue = function(allowOverrides) {
+                return new Config({
+                    // rootUrl is required to pass validation
+                    rootUrl: 'http://irrelevant',
+                    system: {
+                        projectRoot: this.configValue
+                    }
+                }, allowOverrides).system.projectRoot;
+            };
+        });
+
+        afterEach(function() {
+            /*jshint -W069*/
+            delete process.env['gemini_system_project_root'];
+            process.argv = this.oldArgv;
+        });
+
+        it('should not override anything by default', function() {
+            assert.equal(this.getFinalConfigValue(), this.configValue);
+        });
+
+        it('should not override value with env if allowOverredies.env is false', function() {
+            assert.equal(this.getFinalConfigValue({env: false}), this.configValue);
+        });
+
+        it('should override value with env if allowOverredies.env is true', function() {
+            assert.equal(this.getFinalConfigValue({env: true}), this.envValue);
+        });
+
+        it('should not override value with cli if allowOverredies.cli is false', function() {
+            assert.equal(this.getFinalConfigValue({cli: false}), this.configValue);
+        });
+
+        it('should override value with cli if allowOverredies.cli is true', function() {
+            assert.equal(this.getFinalConfigValue({cli: true}), this.cliValue);
+        });
+    });
+});


### PR DESCRIPTION
This restores 0.12 behavior that was unintentionally broken in 0.13:
env vars and cli flags do not have effect on API now.

Fixes #205 