### PR TITLE
Fixes due to removed deprecated fields in runner events in b0b48a1

### DIFF
--- a/lib/errors/no-ref-image-error.js
+++ b/lib/errors/no-ref-image-error.js
@@ -13,10 +13,8 @@ var NoRefImageError = inherit(StateError, {
         this.message = 'Can not find reference image at ' + refImagePath + '.\n' +
             'Run `gemini gather` command to capture all reference images.';
 
-        this.suiteName = result.suiteName;
-        this.suiteId = result.suiteId;
-        this.stateName = result.stateName;
-        this.suitePath = result.suitePath;
+        this.suite = result.suite;
+        this.state = result.state;
         this.browserId = result.browserId;
     }
 });

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -45,10 +45,7 @@ module.exports = inherit(Runner, {
                     return q.reject(new NoRefImageError(refPath,
                         {
                             suite: capture.suite,
-                            suiteName: capture.suite.name,
-                            suiteId: capture.suite.id,
-                            stateName: capture.state.name,
-                            suitePath: capture.suite.path,
+                            state: capture.state,
                             browserId: capture.browser.id
                         }));
                 }


### PR DESCRIPTION
Correctly handle `NoRefImageError`