### PR TITLE
mouseUp action: make element argument optional

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -128,7 +128,7 @@ All methods are chainable:
 
     ```js
     .capture('name', {tolerance: 30}, function(actions, find) {
-    
+
     });
     ```
 
@@ -218,7 +218,8 @@ call:
   element. Possible button values are: 0 – left, 1 – middle, 2 – right. By
   default, left button is used.
 
-* `mouseUp(element)` – release previously pressed mouse button.
+* `mouseUp([element], [button])` – release previously pressed mouse button. If
+  element is specified, move mouse to element and release then.
 
 * `mouseMove(element, [offset])` – move mouse to the given element. Offset is
   specified relatively to the top left corner of the element. If not

--- a/lib/browser/actions.js
+++ b/lib/browser/actions.js
@@ -220,19 +220,19 @@ var Actions = inherit({
             throw new TypeError('Mouse button should be 0 (left), 1 (right) or 2 (middle)');
         }
 
-        if (isInvalidElement(element)) {
-            throw new TypeError('.mouseUp() must receive valid element or CSS selector');
-        }
-
         var _this = this;
-        this._pushAction(this.mouseUp, function mouseDown() {
-            return _this._findElement(element)
-                .then(function(element) {
+        this._pushAction(this.mouseUp, function mouseUp() {
+            var action;
+            if (element) {
+                action = _this._findElement(element).then(function(element) {
                     return _this._driver.moveTo(element);
-                })
-                .then(function() {
-                    return _this._driver.buttonUp(button);
                 });
+            } else {
+                action = q.resolve();
+            }
+            return action.then(function() {
+                return _this._driver.buttonUp(button);
+            });
         });
         return this;
     },


### PR DESCRIPTION
When you performing mouseUp, it is not necessary to specify element. You can just release mouse where it has been pressed.

Sometimes `driver.moveTo()` call in that case may cause some webdriver issues, so it would be nice to make `mouseUp` work without arguments.