### PR TITLE
Use documentElement.clientWidth/Height as viewport

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -29,13 +29,14 @@ exports.prepareScreenshot = function prepareScreenshot(selectors, opts) {
 };
 
 function prepareScreenshotUnsafe(selectors, opts) {
+    resetZoom();
     var rect = getCaptureRect(selectors);
     if (rect.error) {
         return rect;
     }
 
-    var viewportHeight = window.innerHeight || document.documentElement.clientHeight,
-        viewportWidth = window.innerWidth || document.documentElement.clientWidth,
+    var viewportHeight = document.documentElement.clientHeight,
+        viewportWidth = document.documentElement.clientWidth,
         documentHeight = document.documentElement.scrollHeight,
         documentWidth = document.documentElement.scrollWidth,
         coverage,
@@ -46,7 +47,6 @@ function prepareScreenshotUnsafe(selectors, opts) {
             height: viewportHeight
         });
 
-    resetZoom();
     if (!viewPort.rectInside(rect)) {
         window.scrollTo(rect.left, rect.top);
     }


### PR DESCRIPTION
1. On Android, window.innerHeight/Width does not correspond to the
actual viewport as seen by user and WebDriver.
2. jQuery also uses this for detecting viewport.

@j0tunn @scf2k 