### PR TITLE
Run tests only on node 4 and 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-- '0.12'
+- '4'
 - '0.10'
-- iojs
 sudo: false
 script:
 - npm run lint


### PR DESCRIPTION
iojs & 0.12 had no particulary wide spread, so I assume we can
drop them and test in node 4.x instead.