### PR TITLE
Allow some capture elements to be missing

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -86,11 +86,7 @@ function getCaptureRect(selectors) {
     for (var i = 0; i < selectors.length; i++) {
         element = query.first(selectors[i]);
         if (!element) {
-            return {
-                error: 'NOTFOUND',
-                message: 'Can not find element with css selector: ' + selectors[i],
-                selector: selectors[i]
-            };
+            continue;
         }
 
         elementRect = getElementCaptureRect(element);


### PR DESCRIPTION
Previously Gemini would through an error if any of the selectors
passed to setCaptureElement were non-existent. This changes the behavior
to only throw an error if all of the selectors are non-existent.

fixes #231