### PR TITLE
fix window.global

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -6,7 +6,11 @@ var util = require('./util'),
     query = require('./query'),
     Rect = rect.Rect;
 
-global.__gemini = exports;
+if (typeof window === 'undefined') {
+    global.__gemini = exports;
+} else {
+    window.__gemini = exports;
+}
 
 exports.query = query;
 


### PR DESCRIPTION
Gemini не делает снимок области по селектору если в контексте страницы есть window.global.
substack/node-browserify#1189