### PR TITLE
Only maximize PhantomJS browser if windowSize is not configured

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -237,6 +237,10 @@ var Browser = inherit({
     },
 
     _shouldMaximize: function() {
+        if (this.config.windowSize) {
+            return false;
+        }
+
         return this.browserName === 'phantomjs';
     },
 

--- a/test/unit/browser.test.js
+++ b/test/unit/browser.test.js
@@ -45,6 +45,8 @@ describe('browser', function() {
                 get: sinon.stub().returns(q({})),
                 eval: sinon.stub().returns(q('')),
                 setWindowSize: sinon.stub().returns(q({})),
+                maximize: sinon.stub().returns(q()),
+                windowHandle: sinon.stub().returns(q({})),
                 on: sinon.stub()
             };
 
@@ -99,6 +101,19 @@ describe('browser', function() {
             });
         });
 
+        it('should maximize window if launching phantomjs', function() {
+            var _this = this;
+
+            this.browser = makeBrowser({
+                browserName: 'phantomjs',
+                version: '1.0'
+            }, {calibrate: false});
+
+            return this.launchBrowser().then(function() {
+                assert.called(_this.wd.maximize);
+            });
+        });
+
         describe('with windowSize option', function() {
             beforeEach(function() {
                 this.browser.config.windowSize = {width: 1024, height: 768};
@@ -108,6 +123,13 @@ describe('browser', function() {
                 var _this = this;
                 return this.launchBrowser().then(function() {
                     assert.calledWith(_this.wd.setWindowSize, 1024, 768);
+                });
+            });
+
+            it('should not maximize window', function() {
+                var _this = this;
+                return this.launchBrowser().then(function() {
+                    assert.notCalled(_this.wd.maximize);
                 });
             });
 


### PR DESCRIPTION
Currently when using PhantomJS as your test browser, `windowSize` configuration in `.gemini.yml` is not applied, as the setting gets overridden during launch. https://github.com/gemini-testing/gemini/issues/289 describes the issue in more detail.

This PR attempts to fix this problem by only applying the workaround introduced in https://github.com/gemini-testing/gemini/commit/ac0549ea249e6b97a020e7e11344280bf07a9a2c if `windowSize` is not configured.