### PR TITLE
Allow tests to skip by browser id

### DIFF
--- a/lib/suite-util.js
+++ b/lib/suite-util.js
@@ -12,6 +12,10 @@ exports.shouldSkip = function(skipped, browser) {
             return true;
         }
 
+        if (typeof skipBrowser.id !== 'undefined') {
+            return skipBrowser.id === browser.id;
+        }
+
         if (skipBrowser.browserName !== browser.browserName) {
             return false;
         }

--- a/lib/tests-api.js
+++ b/lib/tests-api.js
@@ -13,16 +13,28 @@ function makeSkipBrowser(browser) {
         throw new TypeError('suite.skip browsers must be strings or object');
     }
 
-    if (!browser.browserName) {
-        throw new Error('browserName is not specified');
-    }
+    if ('browserName' in browser) {
+        if (!browser.browserName) {
+            throw new Error('browserName is not specified');
+        }
 
-    if (typeof browser.browserName !== 'string') {
-        throw new TypeError('browserName must be a string');
-    }
+        if (typeof browser.browserName !== 'string') {
+            throw new TypeError('browserName must be a string');
+        }
 
-    if ('version' in browser && typeof browser.version !== 'string') {
-        throw new TypeError('version must be a string');
+        if ('version' in browser && typeof browser.version !== 'string') {
+            throw new TypeError('version must be a string');
+        }
+    } else if ('id' in browser) {
+        if (!browser.id) {
+            throw new Error('id is not specified');
+        }
+
+        if (typeof browser.id !== 'string') {
+            throw new TypeError('id must be a string');
+        }
+    } else {
+        throw new Error('browserName or id is not specified');
     }
 
     return browser;

--- a/test/unit/suite-util.test.js
+++ b/test/unit/suite-util.test.js
@@ -45,6 +45,20 @@ describe('suite-util', function() {
                 makeBrowser({browserName: 'browser', version: '1.1'})
             ));
         });
+
+        it('should skip browser if its id matches skip list', function() {
+            assert.isTrue(shouldSkip(
+                [{id: 'browserId'}],
+                makeBrowser({browserName: 'browser', version: '1.0'}, {id: 'browserId'})
+            ));
+        });
+
+        it('should not skip browser if its id is not specified in skip list', function() {
+            assert.isFalse(shouldSkip(
+                [{id: 'browserId2'}],
+                makeBrowser({browserName: 'browser', version: '1.0'}, {id: 'browserId'})
+            ));
+        });
     });
 
     describe('flattenSuites()', function() {

--- a/test/unit/tests-api.test.js
+++ b/test/unit/tests-api.test.js
@@ -394,12 +394,20 @@ describe('public tests API', function() {
                 }.bind(this), TypeError);
             });
 
-            it('should throw if argument is an object and browser name is not specified', function() {
+            it('should throw if argument is an object and browser name or id is not specified', function() {
                 assert.throws(function() {
                     this.context.suite('name', function(suite) {
                         suite.skip({iHaveNo: 'name'});
                     });
                 }.bind(this), Error);
+            });
+
+            it('should throw if browser id is not a string', function() {
+                assert.throws(function() {
+                    this.context.suite('name', function(suite) {
+                        suite.skip({id: true});
+                    });
+                }.bind(this), TypeError);
             });
 
             it('should throw if browser name is not a string', function() {
@@ -433,12 +441,20 @@ describe('public tests API', function() {
                 assert.deepEqual(this.suite.children[0].skipped[0], {browserName: 'opera'});
             });
 
-            it('should accept browser object', function() {
+            it('should accept browser object with browserName', function() {
                 this.context.suite('name', function(suite) {
                     suite.skip({browserName: 'opera'});
                 });
 
                 assert.deepEqual(this.suite.children[0].skipped[0], {browserName: 'opera'});
+            });
+
+            it('should accept browser object with id', function() {
+                this.context.suite('name', function(suite) {
+                    suite.skip({id: 'opera'});
+                });
+
+                assert.deepEqual(this.suite.children[0].skipped[0], {id: 'opera'});
             });
 
             it('should accept array of objects', function() {


### PR DESCRIPTION
Currently, you can only skip a test suite by `browserName`. This PR adds the ability to skip a test by browser id. Example:

In .gemini.yml
~~~{yml}
browsers:
    chrome:
        windowSize: 1440x900
        desiredCapabilities:
            browserName: chrome
    chrome-mobile:
        windowSize: 375x667
        desiredCapabilities:
            browserName: chrome
~~~

In testsuite.js
~~~{js}
gemini.suite('form', function(suite) {
    suite
        .skip({id: 'chrome-mobile'})
        .setUrl('/forms.html');
});
~~~