### PR TITLE
Remove restirction for maximum open concurrent sockets

### DIFF
--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -20,6 +20,10 @@ var Q = require('q'),
 
     DEFAULT_CFG_NAME = '.gemini.yml';
 
+// Hack for node@0.10 and lower
+// Remove restriction for maximum open concurrent sockets
+require('http').globalAgent.maxSockets = Infinity;
+
 function Gemini(config, allowOverrides) {
     QEmitter.call(this);
     config = config || DEFAULT_CFG_NAME;


### PR DESCRIPTION
Dramatically decreases time of tests passage