### PR TITLE
Group skipped tests in the html report

### DIFF
--- a/lib/reporters/html/report.css
+++ b/lib/reporters/html/report.css
@@ -32,6 +32,7 @@
     border-color: #555;
 }
 
+.button.pressed,
 .button:active {
     background: #eee;
 }
@@ -162,4 +163,24 @@
 
 .cswitcher_color_3 {
     background-image: url('data:image/svg+xml;utf8,<svg width="20" height="20" viewBox="0 0 70 70" xmlns="http://www.w3.org/2000/svg"><path fill="#cecece" d="m0 0h35c0 11.67 0 23.33 0 35-11.67 0-23.33 0-35 0v-35"/><g fill="#fff"><path d="m35 0h35v35c-11.67 0-23.33 0-35 0 0-11.67 0-23.33 0-35"/><path d="m0 35c11.67 0 23.33 0 35 0 0 11.67 0 23.33 0 35h-35v-35"/></g><path fill="#cecece" d="m35 35c11.67 0 23.33 0 35 0v35h-35c0-11.67 0-23.33 0-35"/></svg>');
+}
+
+.collapsed {
+    display: none;
+}
+
+.skipped__list {
+    margin: 10px 0;
+    font-weight: bold;
+    color: #ccc;
+}
+
+a:link,
+a:visited {
+    text-decoration: none;
+}
+
+a:hover,
+a:active {
+    text-decoration: underline;
 }

--- a/lib/reporters/html/report.hbs
+++ b/lib/reporters/html/report.hbs
@@ -16,6 +16,18 @@
         <button id="expandAll" class="button">Expand all</button>
         <button id="collapseAll" class="button">Collapse all</button>
         <button id="expandErrors" class="button">Expand errors</button>
+        <button id="showSkipped" class="button">Show skipped</button>
+
+        <div id="skippedList" class="skipped__list collapsed">
+            {{#if skips}}
+                {{#each skips}}
+                    <div>{{suite}} > {{browser}}{{#if comment}}, reason: {{{comment}}}{{/if}}</div>
+                {{/each}}
+            {{/if}}
+            {{#unless skips}}
+                There are no skipped tests
+            {{/unless}}
+        </div>
 
         {{#each suites}}
             {{> suite}}

--- a/lib/reporters/html/report.js
+++ b/lib/reporters/html/report.js
@@ -75,10 +75,16 @@
         });
     }
 
+    function showSkippedList() {
+        document.getElementById('showSkipped').classList.toggle('pressed');
+        document.getElementById('skippedList').classList.toggle('collapsed');
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('expandAll').addEventListener('click', expandAll);
         document.getElementById('collapseAll').addEventListener('click', collapseAll);
         document.getElementById('expandErrors').addEventListener('click', expandErrors);
+        document.getElementById('showSkipped').addEventListener('click', showSkippedList);
         document.body.addEventListener('click', bodyClick);
 
         forEach.call(document.querySelectorAll('.section'), function(section) {

--- a/lib/reporters/html/view-model.js
+++ b/lib/reporters/html/view-model.js
@@ -13,6 +13,7 @@ module.exports = inherit({
      */
     __constructor: function() {
         this._tree = {name: 'root'};
+        this._skips = [];
         this._counter = new TestCounter();
     },
 
@@ -25,6 +26,12 @@ module.exports = inherit({
             skipped: true,
             reason: result.suite.skipComment
         });
+
+        var comment = result.suite.skipComment
+            && result.suite.skipComment.replace(/https?:\/\/[^\s]*/g, function(url) {
+                return '<a target="_blank" href="' + url + '">' + url + '</a>';
+            });
+        this._skips.push({suite: result.suite.name, browser: result.browserId, comment: comment});
 
         this._counter.onSkipped(result);
     },
@@ -92,6 +99,7 @@ module.exports = inherit({
      */
     getResult: function() {
         return _.extend(this._counter.getResult(), {
+            skips: _.uniq(this._skips, JSON.stringify),
             suites: this._tree.children
         });
     },


### PR DESCRIPTION
Initially 'Show skipped' **toggle** button is not pressed:
![default](https://cloud.githubusercontent.com/assets/1412876/11816881/841b7bf6-a363-11e5-851c-e84164eb8d11.png)

If there are no skipped tests in the report and 'Show skipped' button is pressed then there is a message about that.
![noskipped](https://cloud.githubusercontent.com/assets/1412876/11816939/c41bfb7c-a363-11e5-80ab-2920b14041aa.png)

If there are skipped tests in the report and 'Show skipped' button is pressed then list of  **unique** skipped suites appears.
![someskipped](https://cloud.githubusercontent.com/assets/1412876/11817043/32003cd4-a364-11e5-87bb-75f045c447c2.png)

If some comments contain URLs then a trivial RegExp detection is applied. No rocket science for now. Use URLs in comments with caution.
![links](https://cloud.githubusercontent.com/assets/1412876/11817100/7baf67ec-a364-11e5-836c-a4f868260442.png)
