### PR TITLE
Provide image for errors during actions chain execution

### DIFF
--- a/lib/browser/actions.js
+++ b/lib/browser/actions.js
@@ -402,7 +402,8 @@ var Actions = inherit({
             })
             .fail(function(error) {
                 if (error.status === 7) {
-                    return q.reject(new StateError('Could not find element with css selector: ' + error.selector));
+                    return q.reject(new StateError('Could not find element with css selector in actions chain: '
+                        + error.selector));
                 }
                 return q.reject(error);
             });

--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -92,7 +92,7 @@ function getCaptureRect(selectors) {
         if (!element) {
             return {
                 error: 'NOTFOUND',
-                message: 'Can not find element with css selector: ' + selectors[i],
+                message: 'Could not find element with css selector specified in setCaptureElements: ' + selectors[i],
                 selector: selectors[i]
             };
         }

--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -40,22 +40,21 @@ module.exports = inherit({
         this.log('capture "%s" in %o', state.fullName, this.browser);
         return _this.browser.prepareScreenshot(state.captureSelectors, opts)
             .fail(function(e) {
-                return _this.browser.captureFullscreenImage()
-                    .then(function(screenImage) {
-                        _.extend(e, {
-                            suite: state.suite,
-                            state: state,
-                            browserId: _this.browser.id,
-                            sessionId: _this.browser.sessionId,
-                            image: screenImage
-                        });
-                        return q.reject(e);
-                    });
+                return _this.handleError(e);
             })
             .then(function(prepareData) {
                 return _this.browser.captureFullscreenImage()
                     .then(_.bind(_this._cropImage, _this, _, prepareData));
             });
+    },
+
+    handleError: function(error) {
+        return this.browser.captureFullscreenImage()
+            .then(function(screenImage) {
+                error.image = screenImage;
+            })
+            .fail(_.noop)
+            .thenReject(error);
     },
 
     _cropImage: function(screenImage, prepareData) {

--- a/lib/runner/state-runner/state-runner.js
+++ b/lib/runner/state-runner/state-runner.js
@@ -32,6 +32,8 @@ var StateRunner = inherit(Runner, {
         return this._browserSession.runHook(this._state.callback, this._state.suite)
             .then(function() {
                 return _this._capture();
+            }, function(e) {
+                return _this._browserSession.handleError(e);
             })
             .fail(function(e) {
                 _.extend(e, eventData);

--- a/test/unit/capture-session.test.js
+++ b/test/unit/capture-session.test.js
@@ -507,4 +507,48 @@ describe('capture session', function() {
             });
         });
     });
+
+    describe('handleError', function() {
+        beforeEach(function() {
+            this.browser = {
+                captureFullscreenImage: sinon.stub().returns(q({}))
+            };
+            this.session = new CaptureSession(this.browser);
+            this.error = {};
+        });
+
+        it('should always reject', function() {
+            return assert.isRejected(this.session.handleError(this.error));
+        });
+
+        it('should call captureFullscreenImage method', function() {
+            var _this = this;
+
+            return this.session.handleError(this.error).fail(function() {
+                assert.called(_this.browser.captureFullscreenImage);
+            });
+        });
+
+        it('should add an image to error', function() {
+            var _this = this;
+
+            var image = {some: 'thing'};
+            _this.browser.captureFullscreenImage.returns(q.resolve(image));
+
+            return this.session.handleError(this.error).fail(function() {
+                assert.deepEqual(_this.error.image, image);
+            });
+        });
+
+        it('should not add an image to error if can not captureFullscreenImage', function() {
+            var _this = this;
+            _this.browser.captureFullscreenImage = sinon.stub().returns(q.reject({}));
+
+            this.error = new StateError('some error');
+
+            return this.session.handleError(this.error).fail(function(e) {
+                assert.deepEqual(_this.error, e);
+            });
+        });
+    });
 });

--- a/test/unit/runner/state-runner/state-runner.js
+++ b/test/unit/runner/state-runner/state-runner.js
@@ -15,6 +15,7 @@ describe('runner/StateRunner', function() {
 
         session.runHook.returns(q.resolve());
         session.capture.returns(q.resolve());
+        session.handleError.returns(q.resolve());
 
         return session;
     }
@@ -122,6 +123,21 @@ describe('runner/StateRunner', function() {
                         state: state,
                         suite: state.suite
                     });
+                });
+        });
+
+        it('should handle error in state callback', function() {
+            var browserSession = mkBrowserSessionStub_(),
+                state = util.makeStateStub(),
+                runner = mkRunner_(state, browserSession);
+
+            var error = new StateError('some error');
+            browserSession.runHook.returns(q.reject(error));
+
+            return runner.run()
+                .then(function() {
+                    assert.calledOnce(browserSession.handleError);
+                    assert.calledWith(browserSession.handleError, error);
                 });
         });
 


### PR DESCRIPTION
Please have a look, no unit tests yet. I have tested it with the next suite set:
```
var gemini = require('gemini');

gemini.suite('wrong selector in setCaptureElements', function(suite) {
    suite
        .setUrl('/')
        .setCaptureElements('.main-table1')
        .capture('plain')
        .capture('with text', function(actions, find) {
            actions.sendKeys(find('.input__control'), 'hello gemini');
        });
});

gemini.suite('wrong selector in actions chain', function(suite) {
    suite
        .setUrl('/')
        .setCaptureElements('.main-table')
        .capture('plain')
        .capture('with text', function(actions, find) {
            actions.sendKeys(find('.input__control1'), 'hello gemini');
        });
});

gemini.suite('both selectors wrong', function(suite) {
    suite
        .setUrl('/')
        .setCaptureElements('.main-table1')
        .capture('plain')
        .capture('with text', function(actions, find) {
            actions.sendKeys(find('.input__control1'), 'hello gemini');
        });
});
```