### PR TITLE
Fix typo in function name

### DIFF
--- a/lib/cli/deprecations.js
+++ b/lib/cli/deprecations.js
@@ -22,7 +22,7 @@ var REMOVED_ENV_REPLACEMENTS = {
     'GEMINI_WINDOW_SIZE': 'gemini_window_size'
 };
 
-exports.checkForDeperactions = function() {
+exports.checkForDeprecations = function() {
     checkForRemovedOptions();
     checkForRemovedEnvVars();
 };

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -5,7 +5,7 @@ var pkg = require('../../package.json'),
     q = require('q'),
     handleErrors = require('./errors').handleErrors,
     Gemini = require('../gemini'),
-    checkForDeperactions = require('./deprecations').checkForDeperactions;
+    checkForDeprecations = require('./deprecations').checkForDeprecations;
 
 exports.run = function() {
     program
@@ -71,7 +71,7 @@ function collect(newValue, array) {
 function runGemini(method, paths, options) {
     options = options || {};
     return q.fcall(function() {
-            checkForDeperactions();
+            checkForDeprecations();
             return new Gemini(program.config, {cli: true, env: true});
         })
         .then(function(gemini) {


### PR DESCRIPTION
Just in case I ran all tests (including ones in SauceLabs), seems legit.

```
662 passing (6m)
```