### PR TITLE
Passes in all original options when processing media rules

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -164,15 +164,11 @@ module.exports = inherit({
         if (rule.type !== 'rule') {
             if (rule.type === 'media') {
                 rule.rules.forEach(function(childRule) {
+                    opts.group = true;
+
                     this.processRule(
                         childRule,
-                        {
-                            url: opts.url,
-                            out: opts.out,
-                            group: true,
-                            map: opts.map,
-                            docDir: opts.docDir
-                        },
+                        opts,
                         ctx);
                 }, this);
 


### PR DESCRIPTION
`filePath` (set at https://github.com/gemini-testing/gemini/blob/master/lib/coverage.js#L118) is currently not passed into `processRule` when processing media rules. This causes an error on https://github.com/gemini-testing/gemini/blob/master/lib/coverage.js#L202 when generating coverage reports