### PR TITLE
Checks length of selector after pseudo-elements have been removed

### DIFF
--- a/lib/browser/client-scripts/gemini.coverage.js
+++ b/lib/browser/client-scripts/gemini.coverage.js
@@ -74,7 +74,11 @@ function coverageForRule(rule, area, ctx) {
         var re = /:{1,2}(?:after|before|first-letter|first-line|selection)(:{1,2}\w+)?$/;
         // if selector contains pseudo-elements cut it off and try to find element without it
         if (matches.length === 0 && re.test(selector)) {
-            matches = query.all(selector.replace(re, '$1'));
+            var newSelector = selector.replace(re, '$1').trim();
+
+            if (newSelector.length > 0) {
+                matches = query.all(newSelector);
+            }
         }
 
         if (matches.length > 0) {


### PR DESCRIPTION
When the following source selector `*, ::before, ::after` is split and parsed it results in the selector passed to `query.all` being empty, so I've added a length check