### PR TITLE
Enabled uncaughtException logging

### DIFF
--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -27,10 +27,8 @@ function Gemini(config, allowOverrides) {
     QEmitter.call(this);
     config = config || DEFAULT_CFG_NAME;
     this.config = new Config(config, allowOverrides);
-    if (this.config.system.debug) {
-        debug.enable('gemini:*');
-        qDebugMode(Q);
-    }
+
+    setupLog(this.config.system.debug);
 
     var _this = this;
 
@@ -185,6 +183,18 @@ function applyReporter(runner, reporter) {
     }
 
     reporter(runner);
+}
+
+function setupLog(isDebug) {
+    process.on('uncaughtException', function(err) {
+        console.error(err);
+        process.exit(1);
+    });
+
+    if (isDebug) {
+        qDebugMode(Q);
+        debug.enable('gemini:*');
+    }
 }
 
 module.exports = Gemini;


### PR DESCRIPTION
Always prints uncaught exceptions 