### PR TITLE
Do zoom reset after page load instead of before screenshot

### DIFF
--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -33,7 +33,6 @@ exports.prepareScreenshot = function prepareScreenshot(selectors, opts) {
 };
 
 function prepareScreenshotUnsafe(selectors, opts) {
-    resetZoom();
     var rect = getCaptureRect(selectors);
     if (rect.error) {
         return rect;
@@ -75,7 +74,7 @@ function prepareScreenshotUnsafe(selectors, opts) {
     };
 }
 
-function resetZoom() {
+exports.resetZoom = function() {
     var meta = query.first('meta[name="viewport"]');
     if (!meta) {
         meta = document.createElement('meta');
@@ -83,7 +82,7 @@ function resetZoom() {
         query.first('head').appendChild(meta);
     }
     meta.content = 'width=device-width,initial-scale=1.0,user-scalable=no';
-}
+};
 
 function getCaptureRect(selectors) {
     var element, elementRect, rect;

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -162,8 +162,17 @@ var Browser = inherit({
         return this.open(this.config.getAbsoluteUrl(relativeURL));
     },
 
-    open: function(url) {
-        return this._browser.get(url);
+    // Zoom reset should be skipped before calibration cause we're unable to build client scripts before
+    // calibration done. Reset will be executed as 1 of calibration steps.
+    open: function(url, shouldSkipZoomReset) {
+        var _this = this;
+
+        return this._browser.get(url)
+            .then(function(result) {
+                return shouldSkipZoomReset
+                    ? result
+                    : _this._clientBridge.call('resetZoom').thenResolve(result);
+            });
     },
 
     injectScript: function(script) {

--- a/lib/calibrator.js
+++ b/lib/calibrator.js
@@ -25,7 +25,7 @@ Calibrator.prototype.calibrate = function(browser) {
     if (this._cache[browser.id]) {
         return q(this._cache[browser.id]);
     }
-    return browser.open('about:blank')
+    return browser.open('about:blank', true)
         .then(function() {
             return browser.evalScript(clientScriptCalibrate);
         })

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "gemini-coverage"
   ],
   "devDependencies": {
-    "chai": "^2.2.0",
-    "chai-as-promised": "^4.3.0",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.2.0",
     "coveralls": "^2.11.2",
     "husky": "^0.10.2",
     "istanbul": "^0.4.2",
@@ -52,7 +52,7 @@
     "jshint": "^2.7.0",
     "mocha": "^2.1.0",
     "proxyquire": "^1.7.3",
-    "sinon": "^1.14.1",
+    "sinon": "^1.17.3",
     "uglify-js": "^2.4.24"
   },
   "scripts": {

--- a/test/unit/limited-pool.test.js
+++ b/test/unit/limited-pool.test.js
@@ -81,7 +81,7 @@ describe('LimitedPool', function() {
                 .then(function() {
                     return pool.getBrowser('second').timeout(100, 'timeout');
                 });
-            return assert.isRejected(result, /^timeout$/);
+            return assert.isRejected(result, /timeout$/);
         });
 
         it('should launch next browsers after previous are released', function() {

--- a/test/unit/per-browser-limited-pool.test.js
+++ b/test/unit/per-browser-limited-pool.test.js
@@ -64,7 +64,7 @@ describe('PerBrowserLimitedPool', function() {
                     .then(function() {
                         return pool.getBrowser('id').timeout(100, 'timeout');
                     });
-            return assert.isRejected(result, /^timeout$/);
+            return assert.isRejected(result, /timeout$/);
         });
 
         it('should allow to launch different browser when first is over limit', function() {


### PR DESCRIPTION
Установка meta[name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no"] происходит сразу после загрузки страницы. Это позволяет браузеру успеть перерисовать страницу из zoomOut в fullscreen.