### PR TITLE
Remove useless broken Actions.skip method

### DIFF
--- a/lib/browser/actions.js
+++ b/lib/browser/actions.js
@@ -5,7 +5,6 @@ var q = require('q'),
     inherit = require('inherit'),
     wd = require('wd'),
     promiseUtil = require('../promise-util'),
-    suiteUtil = require('../suite-util'),
     StateError = require('../errors/state-error'),
     find = require('../find-func').find;
 
@@ -411,35 +410,6 @@ var Actions = inherit({
 
     perform: function() {
         return promiseUtil.sequence(this._actions);
-    },
-
-    skip: function(browser) {
-        var _this = this,
-            last = this._actions.length - 1,
-            action = this._actions[last],
-            skip;
-
-        if (last < 0) {
-            throw new RangeError('There is no action defined to skip.');
-        }
-
-        if (!browser) {
-            skip = true;
-        } else if (!Array.isArray(browser)) {
-            skip = [browser];
-        } else {
-            skip = browser;
-        }
-
-        this._actions[last] = function skipAction() {
-            if (suiteUtil.shouldSkip({skipped: skip}, _this._browser.id)) {
-                return q.resolve();
-            }
-
-            return action.apply();
-        };
-
-        return this;
     }
 });
 


### PR DESCRIPTION
It was broken in `2.0.0` when `skip` logic was revised.
And it is really useless feature