### PR TITLE
Applying pixelRatio to viewport dimension when calculating toImageCoordsFunction

### DIFF
--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -123,9 +123,8 @@ module.exports = inherit({
     },
 
     _getToImageCoordsFunction: function(image, prepareData) {
-        var imageSize = image.getSize(),
-            scaleCoords = this._getCoordsScaleFunction(prepareData);
-        if (imageSize.height >= prepareData.documentHeight && imageSize.width >= prepareData.documentWidth) {
+        var scaleCoords = this._getCoordsScaleFunction(prepareData);
+        if (this._shouldUsePageCoords(image, prepareData)) {
             this.log('using page coordinates');
             return function toImageCoords(area) {
                 return scaleCoords(area);
@@ -159,6 +158,20 @@ module.exports = inherit({
 
         this.log('coordinates will not be scaled');
         return _.identity;
+    },
+
+    _shouldUsePageCoords: function(image, prepareData) {
+        var documentWidth = this._scaleDocumentDimension(prepareData.documentWidth, prepareData.pixelRatio),
+            documentHeight = this._scaleDocumentDimension(prepareData.documentHeight, prepareData.pixelRatio),
+            imageSize = image.getSize();
+
+        return imageSize.height >= documentHeight && imageSize.width >= documentWidth;
+    },
+
+    _scaleDocumentDimension: function(dimension, pixelRatio) {
+        return this.browser.usePixelRatio
+            ? dimension * pixelRatio
+            : dimension;
     }
 });
 

--- a/test/unit/capture-session.test.js
+++ b/test/unit/capture-session.test.js
@@ -506,6 +506,68 @@ describe('capture session', function() {
                     });
             });
         });
+
+        describe('if document shorter than image', function() {
+            it('should ignore viewport offset if image size >= document dimension * pixel ratio', function() {
+                this.setCaptureData({
+                    documentSize: {width: 1000, height: 1000},
+                    imageSize: {width: 2000, height: 2000},
+                    pixelRatio: 2,
+                    viewportOffset: {top: 1000, left: 1000},
+                    captureArea: {top: 10, left: 10}
+                });
+                this.browser.usePixelRatio = true;
+
+                var _this = this;
+                return this.performCapture()
+                    .then(function() {
+                        assert.calledWithMatch(_this.image.crop, {
+                            top: 10 * 2,
+                            left: 10 * 2
+                        });
+                    });
+            });
+
+            it('should ignore viewport offset if browser should not use pixel ratio', function() {
+                this.setCaptureData({
+                    documentSize: {width: 1000, height: 1000},
+                    imageSize: {width: 2000, height: 2000},
+                    pixelRatio: 2,
+                    viewportOffset: {top: 5, left: 5},
+                    captureArea: {top: 10, left: 10}
+                });
+                this.browser.usePixelRatio = false;
+
+                var _this = this;
+                return this.performCapture()
+                    .then(function() {
+                        assert.calledWithMatch(_this.image.crop, {
+                            top: 10,
+                            left: 10
+                        });
+                    });
+            });
+
+            it('should apply viewport offset if image size < document dimensions * pixel ratio', function() {
+                this.setCaptureData({
+                    documentSize: {width: 1000, height: 1000},
+                    imageSize: {width: 2000, height: 2000},
+                    pixelRatio: 3,
+                    viewportOffset: {top: 5, left: 5},
+                    captureArea: {top: 100, left: 100}
+                });
+                this.browser.usePixelRatio = true;
+
+                var _this = this;
+                return this.performCapture()
+                    .then(function() {
+                        assert.calledWithMatch(_this.image.crop, {
+                            top: 100 * 3 - 5 * 3,
+                            left: 100 * 3 - 5 * 3
+                        });
+                    });
+            });
+        });
     });
 
     describe('handleError', function() {


### PR DESCRIPTION
Если определён `pixelRatio` и необходимо его использовать, то при вычислении необходимости применять `viewportOffset` `documentSize` умножается на `pixelRatio`, т.к. предполагается, что с клиента он приходит в логическом размере, а расчёты ведутся в физическом. 