### PR TITLE
Implement configurable html report dir

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -49,6 +49,7 @@ sets:
 system:
   projectRoot: ../project
   sourceRoot: ../project/src
+  reportRoot: my-report
   plugins:
     teamcity: true
   debug: true
@@ -76,6 +77,10 @@ settings. These settings can not be set per-browser.
   will be used in the coverage report when the source map is available, but
   the sources can not be downloaded via URLs from the test pages. By default,
   it is equal to `projectRoot`.
+
+* `reportRoot` – directory which html report file will be written to. By default,
+  it is equal to `gemini-report`.
+
 
 * `plugins` - list of plugins to enable. Should have form of `pluginName:
   settings`.  For example:

--- a/lib/config/options.js
+++ b/lib/config/options.js
@@ -33,6 +33,14 @@ module.exports = root(
                 }
             }),
 
+            reportRoot: option({
+                validate: is('string'),
+                map: resolveWithProjectRoot,
+                defaultValue: function(config) {
+                    return 'gemini-report';
+                }
+            }),
+
             plugins: anyObject(),
 
             debug: booleanOption(false),

--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -2,13 +2,12 @@
 
 var path = require('path'),
 
+    _  = require('lodash'),
     q = require('q'),
     fs = require('q-io/fs'),
 
     view = require('./view'),
     ViewModel = require('./view-model'),
-    lib = require('./lib'),
-
     RunnerEvents = require('../../constants/runner-events');
 
 /**
@@ -38,9 +37,9 @@ function makeDirFor(destPath) {
     return fs.makeTree(path.dirname(destPath));
 }
 
-function prepareViewData(runner) {
+function prepareViewData(lib, runner) {
     var result = q.defer(),
-        model = new ViewModel();
+        model = new ViewModel(lib);
 
     runner.on(RunnerEvents.SKIP_STATE, model.addSkipped.bind(model));
 
@@ -66,7 +65,7 @@ function logError(e) {
     console.error(e.stack);
 }
 
-function prepareImages(runner) {
+function prepareImages(lib, runner) {
     var imagesReady = q.defer(),
         queue = q(true);
 
@@ -114,12 +113,14 @@ function prepareImages(runner) {
 }
 
 module.exports = function htmlReporter(tester) {
+    var lib = require('./lib')(tester.config.system.reportRoot);
+
     q.all([
-        prepareViewData(tester),
-        prepareImages(tester)
+        prepareViewData(lib, tester),
+        prepareImages(lib, tester)
     ])
-        .spread(view.createHtml)
-        .then(view.save)
-        .fail(logError)
-        .done();
+    .spread(view.createHtml)
+    .then(_.partial(view.save, lib))
+    .fail(logError)
+    .done();
 };

--- a/lib/reporters/html/lib.js
+++ b/lib/reporters/html/lib.js
@@ -1,34 +1,34 @@
 'use strict';
 
 var _  = require('lodash'),
-    path = require('path'),
+    path = require('path');
 
-    REPORT_OUT_DIR = 'gemini-report',
-
-    referencePath = _.partial(createPath, 'ref'),
+module.exports = function(reportRoot) {
+    var referencePath = _.partial(createPath, 'ref'),
     currentPath = _.partial(createPath, 'current'),
     diffPath = _.partial(createPath, 'diff'),
 
-    absolutePath = _.partial(path.resolve, REPORT_OUT_DIR);
+    absolutePath = _.partial(path.resolve, reportRoot);
 
-/**
- * @param {String} kind - одно из значение 'ref', 'current', 'diff'
- * @param {StateResult} result
- * @returns {String}
- */
-function createPath(kind, result) {
-    var components = [].concat('images', result.suite.path, result.state.name, result.browserId + '~' + kind + '.png');
-    return path.join.apply(null, components);
-}
+    /**
+     * @param {String} kind - одно из значение 'ref', 'current', 'diff'
+     * @param {StateResult} result
+     * @returns {String}
+     */
+    function createPath(kind, result) {
+        var components = [].concat('images', result.suite.path, result.state.name, result.browserId + '~' + kind + '.png');
+        return path.join.apply(null, components);
+    }
 
-module.exports = {
-    REPORT_DIR: REPORT_OUT_DIR,
+    return {
+        REPORT_DIR: reportRoot,
 
-    referencePath: referencePath,
-    currentPath: currentPath,
-    diffPath: diffPath,
+        referencePath: referencePath,
+        currentPath: currentPath,
+        diffPath: diffPath,
 
-    referenceAbsolutePath: _.compose(absolutePath, referencePath),
-    currentAbsolutePath: _.compose(absolutePath, currentPath),
-    diffAbsolutePath: _.compose(absolutePath, diffPath)
+        referenceAbsolutePath: _.compose(absolutePath, referencePath),
+        currentAbsolutePath: _.compose(absolutePath, currentPath),
+        diffAbsolutePath: _.compose(absolutePath, diffPath)
+    };
 };

--- a/lib/reporters/html/view-model.js
+++ b/lib/reporters/html/view-model.js
@@ -2,7 +2,6 @@
 
 var _ = require('lodash'),
     inherit = require('inherit'),
-    lib = require('./lib'),
     TestCounter = require('../utils/test-counter');
 
 var NO_STATE = 'NO_STATE';
@@ -11,10 +10,11 @@ module.exports = inherit({
     /**
      * @constructor
      */
-    __constructor: function() {
+    __constructor: function(lib) {
         this._tree = {name: 'root'};
         this._skips = [];
         this._counter = new TestCounter();
+        this._lib = lib;
     },
 
     /**
@@ -43,8 +43,8 @@ module.exports = inherit({
         this._addTestResult(result, {
             name: result.browserId,
             success: true,
-            actualPath: lib.currentPath(result),
-            expectedPath: lib.referencePath(result)
+            actualPath: this._lib.currentPath(result),
+            expectedPath: this._lib.referencePath(result)
         });
 
         this._counter.onPassed(result);
@@ -57,9 +57,9 @@ module.exports = inherit({
         this._addTestResult(result, {
             name: result.browserId,
             fail: true,
-            actualPath: lib.currentPath(result),
-            expectedPath: lib.referencePath(result),
-            diffPath: lib.diffPath(result)
+            actualPath: this._lib.currentPath(result),
+            expectedPath: this._lib.referencePath(result),
+            diffPath: this._lib.diffPath(result)
         });
 
         this._counter.onFailed(result);
@@ -71,7 +71,7 @@ module.exports = inherit({
     addError: function(result) {
         this._addTestResult(result, {
             name: result.browserId,
-            actualPath: result.state? lib.currentPath(result) : '',
+            actualPath: result.state? this._lib.currentPath(result) : '',
             error: true,
             image: !!result.image || !!result.currentPath,
             reason: (result.stack || result.message || result || '')
@@ -87,7 +87,7 @@ module.exports = inherit({
         this._addTestResult(result, {
             name: result.browserId,
             warning: true,
-            actualPath: lib.currentPath(result),
+            actualPath: this._lib.currentPath(result),
             reason: (result.message || '')
         });
 

--- a/lib/reporters/html/view.js
+++ b/lib/reporters/html/view.js
@@ -7,10 +7,7 @@ var _ = require('lodash'),
     path = require('path'),
 
     hasFails = require('./view-model').hasFails,
-    hasWarnings = require('./view-model').hasWarnings,
-    REPORT_DIR = require('./lib').REPORT_DIR,
-
-    makeOutFilePath = _.partial(path.join, REPORT_DIR);
+    hasWarnings = require('./view-model').hasWarnings;
 
 Handlebars.registerHelper('status', function() {
     if (this.skipped) {
@@ -40,10 +37,6 @@ function loadTemplate(name) {
     return fs.read(path.join(__dirname, name));
 }
 
-function copyToReportDir(fileName) {
-    return fs.copy(path.join(__dirname, fileName), makeOutFilePath(fileName));
-}
-
 module.exports = {
     /**
      * @param {ViewModelResult} model
@@ -65,8 +58,14 @@ module.exports = {
      * @param {String} html
      * returns {Promise}
      */
-    save: function(html) {
-        return fs.makeTree(REPORT_DIR)
+    save: function(lib, html) {
+        var makeOutFilePath = _.partial(path.join, lib.REPORT_DIR);
+
+        function copyToReportDir(fileName) {
+            return fs.copy(path.join(__dirname, fileName), makeOutFilePath(fileName));
+        }
+
+        return fs.makeTree(lib.REPORT_DIR)
             .then(function() {
                 return q.all([
                     fs.write(makeOutFilePath('index.html'), html),

--- a/test/unit/config-options/config-options.test.js
+++ b/test/unit/config-options/config-options.test.js
@@ -298,6 +298,39 @@ describe('config', function() {
             });
         });
 
+        describe('reportRoot', function() {
+            it('should be equal to gemini-report by default', function() {
+                var config = createConfig({
+                    system: {
+                        projectRoot: '/some/absolute/path'
+                    }
+                });
+
+                assert.equal(config.system.reportRoot, '/some/absolute/path/gemini-report');
+            });
+
+            it('should resolve relative paths relatively to projectRoot', function() {
+                var config = createConfig({
+                    system: {
+                        projectRoot: '/root',
+                        reportRoot: './rel/path'
+                    }
+                });
+                assert.equal(config.system.reportRoot, '/root/rel/path');
+            });
+
+            it('should leave absolute path unchanged', function() {
+                var config = createConfig({
+                    system: {
+                        projectRoot: '/root',
+                        reportRoot: '/some/absolute/path'
+                    }
+                });
+
+                assert.equal(config.system.reportRoot, '/some/absolute/path');
+            });
+        });
+
         describe('debug', function() {
             testBooleanOption('system.debug', {default: false});
         });


### PR DESCRIPTION
It is okey to couple the gemini configuration with the html reporter?

Anyhow I think it'd be a big plus if there would be a way to configure where the the html reports are written.
