### PR TITLE
ActionsBuilder: cache found element per browser

### DIFF
--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -12,7 +12,6 @@ var util = require('util'),
 module.exports = inherit({
     __constructor: function(browser) {
         this.browser = browser;
-        this._context = {};
         this.log = debug('gemini:capture:' + this.browser.id);
         this._postActions = [];
     },

--- a/lib/tests-api/actions-builder.js
+++ b/lib/tests-api/actions-builder.js
@@ -376,8 +376,8 @@ function serializeFunc(func) {
 }
 
 function findElement(element, browser) {
-    if (element._element) {
-        return q.resolve(element._element);
+    if (element.cache && element.cache[browser.sessionId]) {
+        return q.resolve(element.cache[browser.sessionId]);
     }
 
     if (typeof element === 'string') {
@@ -386,19 +386,17 @@ function findElement(element, browser) {
 
     return browser.findElement(element._selector)
         .then(function(foundElement) {
-            Object.defineProperty(element, '_element', {
-                value: foundElement,
-                writable: false,
-                enumerable: false
-            });
+            element.cache = element.cache || {};
+            element.cache[browser.sessionId] = foundElement;
 
             return foundElement;
         })
         .fail(function(error) {
             if (error.status === 7) {
-                return q.reject(new StateError('Could not find element with css selector in actions chain: '
-                    + error.selector));
+                error = new StateError('Could not find element with css selector in actions chain: '
+                    + error.selector);
             }
+
             return q.reject(error);
         });
 }


### PR DESCRIPTION
Fix after https://github.com/gemini-testing/gemini/pull/398

В gemini умный find, который запоминает результат выполнения `findElement`. Сейчас он это делает с помощью модификации объекта, который вернула функция `find`. Соответственно получается что элемент нашелся в первом браузере, закэшировался и к нему идут обращения из других браузеров - и все ломается.
Переделал кэш с учетом браузеров