### PR TITLE
Child suite context should have same data as parent has

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -24,6 +24,7 @@ var Suite = inherit({
         this.beforeActions = [];
         this.afterActions = [];
         this.browsers = [];
+        this.context = {};
         definePrivate(this);
     },
 
@@ -99,7 +100,7 @@ exports.create = function createSuite(name, parent) {
     definePrivate(suite);
     suite.name = name;
     suite.path = parent.path? parent.path.concat(name) : [name];
-    suite.context = {};
+    suite.context = _.clone(parent.context);
     parent.addChild(suite);
     return suite;
 };

--- a/test/unit/suite.test.js
+++ b/test/unit/suite.test.js
@@ -41,6 +41,26 @@ describe('suite', function() {
 
             assert.include(parent.children, child);
         });
+
+        it('child suite should have same data in context as parent', function() {
+            var parent = createSuite('parent');
+            parent.context.some = 'data';
+
+            var child = createSuite('child', parent);
+
+            assert.deepEqual(child.context, {some: 'data'});
+        });
+
+        it('modifications of child context should not affect parent context', function() {
+            var parent = createSuite('parent');
+            parent.context.some = 'data';
+
+            var child = createSuite('child', parent);
+            child.context.some = 'other-data';
+            child.context.other = 'data';
+
+            assert.deepEqual(parent.context, {some: 'data'});
+        });
     });
 
     describe('states', function() {


### PR DESCRIPTION
Иначе если в родительском `before` что-то сохраняется в `context`, то в коллбэках дочернего сьюта это что-то недоступно