### PR TITLE
If image validation failed then error will be thrown instead of returning image

### DIFF
--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var util = require('util'),
+var q = require('q'),
+    util = require('util'),
     inherit = require('inherit'),
     _ = require('lodash'),
-    logger = require('./utils').logger,
     debug = require('debug'),
     promiseUtil = require('q-promise-utils'),
     ActionsBuilder = require('./tests-api/actions-builder'),
@@ -69,18 +69,13 @@ var CaptureSession = inherit({
         var toImageCoords = this._getToImageCoordsFunction(screenImage, pageDisposition),
             cropArea = toImageCoords(pageDisposition.captureArea);
 
-        try {
-            this._validateImage(screenImage, cropArea);
-        } catch (err) {
-            logger.error(err.message);
-            return {image: screenImage};
-        }
+        return this._validateImage(screenImage, cropArea)
+            .then(() => {
+                pageDisposition.ignoreAreas.forEach(area => screenImage.clear(toImageCoords(area)));
 
-        pageDisposition.ignoreAreas.forEach(function(area) {
-            screenImage.clear(toImageCoords(area));
-        });
-        return screenImage.crop(cropArea)
-            .then(function(crop) {
+                return screenImage.crop(cropArea);
+            })
+            .then(crop => {
                 return {
                     image: crop,
                     canHaveCaret: pageDisposition.canHaveCaret
@@ -98,7 +93,7 @@ var CaptureSession = inherit({
             // This case is handled specially because of Opera 12 browser.
             // Problem, described in error message occurs there much more often then
             // for other browsers and has different workaround
-            throw new StateError(util.format(
+            return reportError_(util.format(
                 'Failed to capture the element because it is positioned outside of the captured body. ' +
                 'Most probably you are trying to capture an absolute positioned element which does not make body ' +
                 'height to expand. To fix this place a tall enough <div> on the page to make body expand.\n' +
@@ -109,21 +104,32 @@ var CaptureSession = inherit({
                 cropArea.height,
                 imageSize.width,
                 imageSize.height
-            ));
+            ), image);
         }
 
         if (isOutsideOfImage(imageSize, cropArea)) {
             this.log('crop area is outside of image');
-            throw new StateError(
+            return reportError_(
                 'Can not capture specified region of the page\n' +
                 'The size of a region is larger then image, captured by browser\n' +
                 'Check that elements:\n' +
                 ' - does not overflows the document\n' +
                 ' - does not overflows browser viewport\n ' +
                 'Alternatively, you can increase browser window size using\n' +
-                '"setWindowSize" or "windowSize" option in config file.'
-
+                '"setWindowSize" or "windowSize" option in config file.',
+                image
             );
+        }
+
+        return q();
+
+        function reportError_(message, screenImage) {
+            const path = temp.path({suffix: '.png'});
+            const error = new StateError((message));
+
+            return screenImage.save(path)
+                .then(() => error.imagePath = path)
+                .thenReject(error);
         }
     },
 

--- a/test/unit/capture-session.test.js
+++ b/test/unit/capture-session.test.js
@@ -120,6 +120,7 @@ describe('capture session', function() {
             sandbox.stub(Image.prototype);
             Image.prototype.crop.returns(q({}));
             Image.prototype.getSize.returns({});
+            Image.prototype.save.returns(q());
         });
 
         function mkBrowserStub_() {
@@ -221,13 +222,87 @@ describe('capture session', function() {
                     });
             });
 
+            it('should return error if left boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {left: 1001}
+                };
+
+                return assert.isRejected(doCapture_(captureParams), StateError);
+            });
+
+            it('should save page screenshot if left boundary is outside of image', () => {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {left: 1001}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.calledWith(Image.prototype.save, '/path/to/img');
+                    });
+            });
+
+            it('should extend error with path to page screenshot if left boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {left: 1001}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.equal(error.imagePath, '/path/to/img');
+                    });
+            });
+
             it('should not crop image if left boundary is outside of image', function() {
                 return doCapture_({
                         documentSize: {width: 1000, height: 1000},
                         captureArea: {left: 1001}
                     })
-                    .then(function() {
+                    .fail(function() {
                         assert.notCalled(Image.prototype.crop);
+                    });
+            });
+
+            it('should return error if right boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {left: 900, width: 101}
+                };
+
+                return assert.isRejected(doCapture_(captureParams), StateError);
+            });
+
+            it('should save page screenshot if right boundary is outside of image', () => {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {left: 900, width: 101}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.calledWith(Image.prototype.save, '/path/to/img');
+                    });
+            });
+
+            it('should extend error with path to page screenshot if right boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {left: 900, width: 101}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.equal(error.imagePath, '/path/to/img');
                     });
             });
 
@@ -236,8 +311,45 @@ describe('capture session', function() {
                         documentSize: {width: 1000, height: 1000},
                         captureArea: {left: 900, width: 101}
                     })
-                    .then(function() {
+                    .fail(function() {
                         assert.notCalled(Image.prototype.crop);
+                    });
+            });
+
+            it('should return error if top boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {top: 1001}
+                };
+
+                return assert.isRejected(doCapture_(captureParams), StateError);
+            });
+
+            it('should save page screenshot if top boundary is outside of image', () => {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {top: 1001}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.calledWith(Image.prototype.save, '/path/to/img');
+                    });
+            });
+
+            it('should extend error with path to page screenshot if top boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {top: 1001}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.deepEqual(error.imagePath, '/path/to/img');
                     });
             });
 
@@ -246,8 +358,45 @@ describe('capture session', function() {
                         documentSize: {width: 1000, height: 1000},
                         captureArea: {top: 1001}
                     })
-                    .then(function() {
+                    .fail(function() {
                         assert.notCalled(Image.prototype.crop);
+                    });
+            });
+
+            it('should return error if bottom boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {top: 900, height: 101}
+                };
+
+                return assert.isRejected(doCapture_(captureParams), StateError);
+            });
+
+            it('should save page screenshot if bottom boundary is outside of image', () => {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {top: 900, height: 101}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.calledWith(Image.prototype.save, '/path/to/img');
+                    });
+            });
+
+            it('should extend error with path to page screenshot if bottom boundary is outside of image', function() {
+                const captureParams = {
+                    documentSize: {width: 1000, height: 1000},
+                    captureArea: {top: 900, height: 101}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.equal(error.imagePath, '/path/to/img');
                     });
             });
 
@@ -256,7 +405,7 @@ describe('capture session', function() {
                         documentSize: {width: 1000, height: 1000},
                         captureArea: {top: 900, height: 101}
                     })
-                    .then(function() {
+                    .fail(function() {
                         assert.notCalled(Image.prototype.crop);
                     });
             });
@@ -340,13 +489,38 @@ describe('capture session', function() {
                     });
             });
 
+            it('should return error if capture area is outside image', function() {
+                const captureParams = {
+                    imageSize: {width: 1000, height: 1000},
+                    captureArea: {top: 900, height: 101 + 1},
+                    viewportOffset: {top: 1}
+                };
+
+                assert.isRejected(doCapture_(captureParams), StateError);
+            });
+
+            it('should extend error with path to page screenshot if capture area is outside image', function() {
+                const captureParams = {
+                    imageSize: {width: 1000, height: 1000},
+                    captureArea: {top: 900, height: 101 + 1},
+                    viewportOffset: {top: 1}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.equal(error.imagePath, '/path/to/img');
+                    });
+            });
+
             it('should not crop image if capture area is outside of image', function() {
                 return doCapture_({
                         imageSize: {width: 1000, height: 1000},
                         captureArea: {top: 900, height: 101 + 1},
                         viewportOffset: {top: 1}
                     })
-                    .then(function(data) {
+                    .fail(function(data) {
                         assert.notCalled(Image.prototype.crop);
                     });
             });
@@ -400,12 +574,52 @@ describe('capture session', function() {
                     });
             });
 
+            it('should throw error if capture area is outside of image', function() {
+                const captureParams = {
+                    imageSize: {width: 1000, height: 1000},
+                    captureArea: {left: 900, width: 102},
+                    viewportOffset: {left: 1}
+                };
+
+                return assert.isRejected(doCapture_(captureParams), StateError);
+            });
+
+            it('should save page screenshot if capture area is outside image', function() {
+                const captureParams = {
+                    imageSize: {width: 1000, height: 1000},
+                    captureArea: {left: 900, width: 102},
+                    viewportOffset: {left: 1}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.calledWith(Image.prototype.save, '/path/to/img');
+                    });
+            });
+
+            it('should extend error with path to page screenshot if capture area is outside image', function() {
+                const captureParams = {
+                    imageSize: {width: 1000, height: 1000},
+                    captureArea: {left: 900, width: 102},
+                    viewportOffset: {left: 1}
+                };
+
+                temp.path.returns('/path/to/img');
+
+                return doCapture_(captureParams)
+                    .fail(function(error) {
+                        assert.equal(error.imagePath, '/path/to/img');
+                    });
+            });
+
             it('should not crop image if capture area outside of image', function() {
                 return doCapture_({
                         imageSize: {width: 1000, height: 1000},
                         captureArea: {left: 900, width: 102},
                         viewportOffset: {left: 1}
-                    }).then(function(data) {
+                    }).fail(function(data) {
                         assert.notCalled(Image.prototype.crop);
                     });
             });


### PR DESCRIPTION
Если произошла ошибка вида "элемент за пределами страницы", то вылетает ошибка, вместо того, чтобы возвращать скриншот всего экрана