### PR TITLE
Repaired require for default `.gemini.js` and `.gemini.json`

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -76,8 +76,12 @@ function getDefaultConfig() {
         throw new GeminiError('No config found');
     }
 
+    // Add absolute path to config (otherwise we will look for a package named `.gemini.js`)
+    configFile = path.resolve(configFile);
+
     return configFile;
 }
+Config.getDefaultConfig = getDefaultConfig;
 
 function requireModule(file) {
     try {

--- a/test/functional/config.test.js
+++ b/test/functional/config.test.js
@@ -66,4 +66,47 @@ describe('config', function() {
             });
         });
     });
+
+    describe('resolving a default config', function() {
+        describe('non-existant', function() {
+            it('should throw on non-existent file', function() {
+                var cwd = process.cwd();
+                process.chdir(configPath(''));
+                assert.throws(function() {
+                    Config.getDefaultConfig();
+                });
+                process.chdir(cwd);
+            });
+        });
+
+        describe('.yml', function() {
+            it('should return an existent file', function() {
+                var cwd = process.cwd();
+                process.chdir(configPath('default-yml'));
+                var defaultConfig = Config.getDefaultConfig();
+                process.chdir(cwd);
+                assert.match(defaultConfig, /default-yml[\/\\]\.gemini\.yml/);
+            });
+        });
+
+        describe('.js', function() {
+            it('should return an existent file', function() {
+                var cwd = process.cwd();
+                process.chdir(configPath('default-js'));
+                var defaultConfig = Config.getDefaultConfig();
+                process.chdir(cwd);
+                assert.match(defaultConfig, /default-js[\/\\]\.gemini\.js/);
+            });
+        });
+
+        describe('.json', function() {
+            it('should return an existent file', function() {
+                var cwd = process.cwd();
+                process.chdir(configPath('default-json'));
+                var defaultConfig = Config.getDefaultConfig();
+                process.chdir(cwd);
+                assert.match(defaultConfig, /default-json[\/\\]\.gemini\.json/);
+            });
+        });
+    });
 });

--- a/test/functional/data/config/default-js/.gemini.js
+++ b/test/functional/data/config/default-js/.gemini.js
@@ -1,0 +1,12 @@
+module.exports = {
+    system: {
+        projectRoot: '/it/works'
+    },
+    gridUrl: 'http://grid.example.com',
+    rootUrl: 'http://example.com',
+    browsers: {
+        example: {
+            desiredCapabilities: {}
+        }
+    }
+};

--- a/test/functional/data/config/default-json/.gemini.json
+++ b/test/functional/data/config/default-json/.gemini.json
@@ -1,0 +1,12 @@
+{
+    "system": {
+        "projectRoot": "/it/works"
+    },
+    "gridUrl": "http://grid.example.com",
+    "rootUrl": "http://example.com",
+    "browsers": {
+        "example": {
+            "desiredCapabilities": {}
+        }
+    }
+}

--- a/test/functional/data/config/default-yml/.gemini.yml
+++ b/test/functional/data/config/default-yml/.gemini.yml
@@ -1,0 +1,6 @@
+system: {projectRoot: '/it/works'}
+gridUrl: http://grid.example.com
+rootUrl: http://example.com
+browsers:
+  example:
+    desiredCapabilities: {}


### PR DESCRIPTION
I'm experimenting with a script that requires a dynamically computed `.gemini.js` (depends on node module for path to executable). However, when I ran Gemini I saw that it was getting a `MODULE_NOT_FOUND` error for `.gemini.js` despite it working earlier for `.gemini.yml`.

After some digging, I found that we were essentially running `require('.gemini.js')` which tells Node.js to look for a package named `.gemini.js` instead of the local file (i.e. `./.gemini.js`). I have resolved that in this PR by moving to an absolute path for `.gemini.js`/`.gemini.json`.

In this PR:

- Updated `getDefaultConfig` to return absolute path for non-YAML files

**Notes:**

We could use `fs.readFile` and `JSON.parse`/`vm.runInContext` (since `fs.readFile` resolves from `process.cwd()` but this is much simpler.