### PR TITLE
Changed require configuration to path relative to current working dir…

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -53,6 +53,14 @@ Config.prototype.isCoverageEnabled = function() {
     return this.system.coverage.enabled;
 };
 
+Config.isRelativePath = function(file) {
+    return file.indexOf('./') === 0 || file.indexOf('/') !== 0;
+};
+
+Config.getAbsPath = function(file) {
+    return process.cwd() + '/' + file;
+};
+
 function readConfig(filePath) {
     filePath = filePath || getDefaultConfig();
 
@@ -81,7 +89,11 @@ function getDefaultConfig() {
 
 function requireModule(file) {
     try {
-        return require(file);
+        if (Config.isRelativePath(file)) {
+            return require(Config.getAbsPath(file));
+        } else {
+            return require(file);
+        }
     } catch (e) {
         if (e.code === 'MODULE_NOT_FOUND') {
             throw new GeminiError('Config file does not exist: ' + file);

--- a/test/functional/config.test.js
+++ b/test/functional/config.test.js
@@ -51,6 +51,16 @@ describe('config', function() {
                     return new Config(configPath('notExists.js'));
                 }, GeminiError);
             });
+
+            it('should read relative to current working directory', function() {
+                assert.deepPropertyVal(
+                  new Config(configPath('validConfig.js').replace(process.cwd() + '/', '')),
+                  'system.projectRoot', '/it/works');
+
+                assert.deepPropertyVal(
+                  new Config(configPath('validConfig.js').replace(process.cwd() + '/', './')),
+                  'system.projectRoot', '/it/works');
+            });
         });
 
         describe('.json', function() {
@@ -63,6 +73,16 @@ describe('config', function() {
                 assert.throws(function() {
                     return new Config(configPath('notExists.json'));
                 }, GeminiError);
+            });
+
+            it('should read relative to current working directory', function() {
+                assert.deepPropertyVal(
+                  new Config(configPath('validConfig.json').replace(process.cwd() + '/', '')),
+                  'system.projectRoot', '/it/works');
+
+                assert.deepPropertyVal(
+                  new Config(configPath('validConfig.json').replace(process.cwd() + '/', './')),
+                  'system.projectRoot', '/it/works');
             });
         });
     });

--- a/test/unit/config-options/config-options.test.js
+++ b/test/unit/config-options/config-options.test.js
@@ -866,4 +866,26 @@ describe('config', function() {
             });
         });
     });
+
+    describe('util functions', function() {
+        it('should return true if path is relative', function() {
+            assert.strictEqual(Config.isRelativePath('./foo/bar'), true);
+            assert.strictEqual(Config.isRelativePath('foo/bar'), true);
+        });
+
+        it('should return false if path is absolute', function() {
+            assert.strictEqual(Config.isRelativePath('/foo/bar'), false);
+        });
+
+        it('should return absolute path by pass relative', function() {
+            var relativePath = 'foo/bar/gemini.config';
+            var relativePathWithLeadedDot = './foo/bar/gemini.config';
+            assert.strictEqual(
+              Config.getAbsPath(relativePath),
+              process.cwd() + '/' + relativePath);
+            assert.strictEqual(
+              Config.getAbsPath(relativePathWithLeadedDot),
+              process.cwd() + '/' + relativePathWithLeadedDot);
+        });
+    });
 });


### PR DESCRIPTION
…ectory

For example working directory is `/home/foo/project_with_gemini/gemini/`.
We use js or json default path configuration or use `-c` option.
Run `./gemini` or `./gemini -c .very_special_configuration.json`.
And we get configuration relative to current working directory:
/home/foo/project_with_gemini/gemini/.gemini.conf.json
/home/foo/project_with_gemini/gemini/.gemini.conf.js
/home/foo/project_with_gemini/gemini/.very_special_configuration.json
not in directory anywhere in the node_modules.
Fixed #418.