### PR TITLE
Fix image crop area calculation for fractional pixel ratio values

### DIFF
--- a/lib/capture-session.js
+++ b/lib/capture-session.js
@@ -164,6 +164,9 @@ module.exports = inherit({
             documentHeight = this._scaleDocumentDimension(prepareData.documentHeight, prepareData.pixelRatio),
             imageSize = image.getSize();
 
+        documentWidth = _.ceil(documentWidth);
+        documentHeight = _.ceil(documentHeight);
+
         return imageSize.height >= documentHeight && imageSize.width >= documentWidth;
     },
 


### PR DESCRIPTION
Add `_.ceil` round up for document size dimensions for prevent invalid usage of "page coordinates" for
controversial cases and fractional pixel ratio value

@sipayRT @j0tunn