### PR TITLE
Fix: require default config file by absolute path

### DIFF
--- a/lib/config/config-reader.js
+++ b/lib/config/config-reader.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs'),
+    path = require('path'),
     yaml = require('js-yaml'),
     _ = require('lodash'),
     GeminiError = require('../errors/gemini-error');
@@ -22,7 +23,7 @@ function getDefaultConfig() {
         throw new GeminiError('No config found');
     }
 
-    return configFile;
+    return path.resolve(configFile);
 }
 
 function requireModule(file) {

--- a/lib/config/config-reader.js
+++ b/lib/config/config-reader.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const fs = require('fs'),
+    yaml = require('js-yaml'),
+    _ = require('lodash'),
+    GeminiError = require('../errors/gemini-error');
+
+exports.read = (filePath) => {
+    filePath = filePath || getDefaultConfig();
+
+    return /\.yml$/.test(filePath)
+        ? readYAMLFile(filePath)
+        : requireModule(filePath);
+};
+
+function getDefaultConfig() {
+    var configFile = _.find(fs.readdirSync('./'), function(file) {
+            return /^\.gemini(\.conf)?\.(yml|js|json)$/.test(file);
+        });
+
+    if (!configFile) {
+        throw new GeminiError('No config found');
+    }
+
+    return configFile;
+}
+
+function requireModule(file) {
+    try {
+        return require(file);
+    } catch (e) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+            throw new GeminiError('Config file does not exist: ' + file);
+        }
+        throw e;
+    }
+}
+
+function readYAMLFile(configPath) {
+    var text = readFile(configPath);
+    return parseYAML(text, configPath);
+}
+
+function readFile(configPath) {
+    try {
+        return fs.readFileSync(configPath, 'utf8');
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            throw new GeminiError(
+                'Config file does not exist: ' + configPath,
+                'Specify config file or configure your project by following\nthe instructions:\n\n' +
+                'https://github.com/bem/gemini#configuration'
+            );
+        }
+        throw e;
+    }
+}
+
+function parseYAML(source, filename) {
+    try {
+        return yaml.safeLoad(source);
+    } catch (e) {
+        throw new GeminiError('Error while parsing a config file: ' + filename + '\n' +
+            e.reason + ' ' + e.mark,
+            'Gemini config should be valid YAML file.'
+        );
+    }
+}

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,11 +1,9 @@
 'use strict';
 
 var path = require('path'),
-    fs = require('fs'),
-    yaml = require('js-yaml'),
     _ = require('lodash'),
-    GeminiError = require('../errors/gemini-error'),
     BrowserConfig = require('./browser-config'),
+    configReader = require('./config-reader'),
 
     parseOptions = require('./options');
 
@@ -54,10 +52,8 @@ Config.prototype.isCoverageEnabled = function() {
 };
 
 function readConfig(filePath) {
-    filePath = filePath || getDefaultConfig();
-
-    var config = /\.yml$/.test(filePath)? readYAMLFile(filePath) : requireModule(filePath),
-        configDir = path.dirname(filePath);
+    var config = configReader.read(filePath),
+        configDir = filePath? path.dirname(filePath) : process.cwd();
 
     if (_.has(config, 'system.projectRoot')) {
         config.system.projectRoot = path.resolve(configDir, config.system.projectRoot);
@@ -65,60 +61,6 @@ function readConfig(filePath) {
         _.set(config, 'system.projectRoot', configDir);
     }
     return config;
-}
-
-function getDefaultConfig() {
-    var configFile = _.find(fs.readdirSync('./'), function(file) {
-            return /^\.gemini(\.conf)?\.(yml|js|json)$/.test(file);
-        });
-
-    if (!configFile) {
-        throw new GeminiError('No config found');
-    }
-
-    return configFile;
-}
-
-function requireModule(file) {
-    try {
-        return require(file);
-    } catch (e) {
-        if (e.code === 'MODULE_NOT_FOUND') {
-            throw new GeminiError('Config file does not exist: ' + file);
-        }
-        throw e;
-    }
-}
-
-function readYAMLFile(configPath) {
-    var text = readFile(configPath);
-    return parseYAML(text, configPath);
-}
-
-function readFile(configPath) {
-    try {
-        return fs.readFileSync(configPath, 'utf8');
-    } catch (e) {
-        if (e.code === 'ENOENT') {
-            throw new GeminiError(
-                'Config file does not exist: ' + configPath,
-                'Specify config file or configure your project by following\nthe instructions:\n\n' +
-                'https://github.com/bem/gemini#configuration'
-            );
-        }
-        throw e;
-    }
-}
-
-function parseYAML(source, filename) {
-    try {
-        return yaml.safeLoad(source);
-    } catch (e) {
-        throw new GeminiError('Error while parsing a config file: ' + filename + '\n' +
-            e.reason + ' ' + e.mark,
-            'Gemini config should be valid YAML file.'
-        );
-    }
 }
 
 module.exports = Config;

--- a/test/unit/config/config-reader.js
+++ b/test/unit/config/config-reader.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const fs = require('fs'),
+    path = require('path'),
+    proxyquire = require('proxyquire').noCallThru(),
+    _ = require('lodash');
+
+describe('config/config-reader', () => {
+    const sandbox = sinon.sandbox.create();
+
+    beforeEach(() => {
+        sandbox.stub(fs, 'readdirSync');
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    function initReader_(files) {
+        fs.readdirSync.returns(_.keys(files));
+
+        return proxyquire('../../../lib/config/config-reader', files);
+    }
+
+    describe('default config (js|json)', () => {
+        function test_(fileName) {
+            it('should read ' + fileName, () => {
+                const files = {};
+                files[fileName] = {some: 'data'};
+                const reader = initReader_(files);
+
+                const result = reader.read();
+
+                assert.deepEqual(result, {some: 'data'});
+            });
+        }
+
+        test_('.gemini.conf.js');
+        test_('.gemini.js');
+        test_('.gemini.conf.json');
+        test_('.gemini.json');
+    });
+});

--- a/test/unit/config/config-reader.js
+++ b/test/unit/config/config-reader.js
@@ -19,6 +19,8 @@ describe('config/config-reader', () => {
     function initReader_(files) {
         fs.readdirSync.returns(_.keys(files));
 
+        files = _.mapKeys(files, (content, filePath) => path.resolve(filePath));
+
         return proxyquire('../../../lib/config/config-reader', files);
     }
 

--- a/test/unit/config/index.js
+++ b/test/unit/config/index.js
@@ -1,8 +1,23 @@
 'use strict';
-var Config = require('../../lib/config'),
+var Config = require('../../../lib/config'),
+    configReader = require('../../../lib/config/config-reader'),
     _ = require('lodash');
 
 describe('config', function() {
+    var sandbox = sinon.sandbox.create();
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    it('should read config file', function() {
+        sandbox.stub(configReader, 'read').returns({rootUrl: ''});
+
+        new Config('/some/path'); // jshint ignore:line
+
+        assert.calledWith(configReader.read, '/some/path');
+    });
+
     describe('overrides', function() {
         beforeEach(function() {
             /*jshint -W069*/


### PR DESCRIPTION
If no config file specified `gemini` will try to read some default configs. In case of `js|json` files `gemini` will just require them. For now it requires them by name and obviously fails.