### PR TITLE
Implement release of unused browser session

### DIFF
--- a/lib/browser-pool/caching-pool.js
+++ b/lib/browser-pool/caching-pool.js
@@ -45,9 +45,20 @@ CachingPool.prototype.getBrowser = function(id) {
         .thenResolve(browser);
 };
 
-CachingPool.prototype.freeBrowser = function(browser) {
-    log('put %o to cache', browser);
-    return this._caches[browser.id].push(browser);
+/**
+ * Free browser
+ * @param {Browser} browser session instance
+ * @param {Object} [options] - advanced options
+ * @param {Boolean} [options.noMoreRequests] - flag which indicates that browser
+ * should be really freed or put into sessions cache
+ * @returns {Promise<undefined>}
+ */
+CachingPool.prototype.freeBrowser = function(browser, options) {
+    log('free %o', browser);
+    const shouldBeFreed = options && options.noMoreRequests;
+    return shouldBeFreed
+        ? this.underlyingPool.freeBrowser(browser)
+        : this._caches[browser.id].push(browser);
 };
 
 CachingPool.prototype.finalizeBrowsers = function(id) {

--- a/lib/browser-pool/limited-pool.js
+++ b/lib/browser-pool/limited-pool.js
@@ -14,6 +14,7 @@ function LimitedPool(limit, underlyingPool) {
     this.underlyingPool = underlyingPool;
     this._limit = limit;
     this._launched = 0;
+    this._requests = 0;
     this._deferQueue = [];
 }
 
@@ -21,6 +22,15 @@ util.inherits(LimitedPool, Pool);
 
 LimitedPool.prototype.getBrowser = function(id) {
     log('get browser %s (launched %d, limit %d)', id, this._launched, this._limit);
+
+    ++this._requests;
+    return this._getBrowser(id).catch((e) => {
+        --this._requests;
+        return q.reject(e);
+    });
+};
+
+LimitedPool.prototype._getBrowser = function(id) {
     if (this._canLaunchBrowser) {
         log('can launch one more');
         this._launched++;
@@ -28,11 +38,9 @@ LimitedPool.prototype.getBrowser = function(id) {
     }
 
     log('queuing the request');
-    var defer = q.defer();
-    this._deferQueue.unshift({
-        id: id,
-        defer: defer
-    });
+    const defer = q.defer();
+    this._deferQueue.unshift({id, defer});
+
     log('queue length: %d', this._deferQueue.length);
     return defer.promise;
 };
@@ -58,7 +66,8 @@ LimitedPool.prototype._newBrowser = function(id) {
 
 LimitedPool.prototype.freeBrowser = function(browser) {
     log('free browser', browser);
-    return this.underlyingPool.freeBrowser(browser)
+    --this._requests;
+    return this.underlyingPool.freeBrowser(browser, {noMoreRequests: this._launched > this._requests})
         .fin(this._launchNextBrowser.bind(this));
 };
 

--- a/test/unit/browser-pool/caching-pool.js
+++ b/test/unit/browser-pool/caching-pool.js
@@ -92,16 +92,21 @@ describe('CachingPool', function() {
     });
 
     it('should not quit browser when freed', function() {
+        const pool = this.makePool();
         this.underlyingPool.getBrowser.returns(q(makeStubBrowser('id')));
-        var _this = this,
-            pool = this.makePool();
+
         return pool.getBrowser('id')
-            .then(function(browser) {
-                return pool.freeBrowser(browser);
-            })
-            .then(function() {
-                assert.notCalled(_this.underlyingPool.freeBrowser);
-            });
+            .then((browser) => pool.freeBrowser(browser, {noMoreRequests: false}))
+            .then(() => assert.notCalled(this.underlyingPool.freeBrowser));
+    });
+
+    it('should quit browser when there are no more requests', function() {
+        const pool = this.makePool();
+        this.underlyingPool.getBrowser.returns(q(makeStubBrowser('id')));
+
+        return pool.getBrowser('id')
+            .then((browser) => pool.freeBrowser(browser, {noMoreRequests: true}))
+            .then(() => assert.calledOnce(this.underlyingPool.freeBrowser));
     });
 
     describe('when there is free browser with same id', function() {


### PR DESCRIPTION
* Yet another counter `requests` was added to `LimitedPool`. This counter is a number which increments itself on each `getBrowser` request and decrements itself on each `freeBrowser` call.
* Error handler has been added to `getBrowser` method for decrease `requests` on fail.
* Boolean flag `shouldBeFreed` has been added to call of `freeBrowser` method of `CachingPool`. Depending on value of `shouldBeFreed` flag `CachingPool` releases browser or puts it into cache (LimitedUseSet)
* value `shouldBeFreed` boolean flag is specified as positive diff between number of registered browser requests and number of launched browsers.

Also tests were added.

@cody @sipayRT @eGavr 
Please review it