### PR TITLE
Fix displaying of retries in HTML report

### DIFF
--- a/lib/reporters/html/view-model.js
+++ b/lib/reporters/html/view-model.js
@@ -137,7 +137,7 @@ module.exports = inherit({
 
         // Hack to avoid situations when `endTest` event is emitted several times for a state, for example,
         // when a state passed, but was retried because of a failure of another state in this suite
-        if (_.isEqual(retry, testResult)) {
+        if (retry.success && testResult.success) {
             return;
         }
 


### PR DESCRIPTION
/cc @sipayRT 

После того как в объект-результат теста мы стали добавлять `sessionId`, хак для отображения ретраев HTML-отчете перестал работать.