### PR TITLE
Support 'changeOrientation' for 'appium' below 1.5.x

### DIFF
--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -58,18 +58,37 @@ module.exports = class NewBrowser extends Browser {
             'execute',
             'setWindowSize',
             'getWindowSize',
-            'getOrientation',
-            'setOrientation'
+            // 'setOrientation' and 'getOrientation' work only in context 'NATIVE_APP' with 'appium' below 1.5.x
+            {name: 'getOrientation', context: 'NATIVE_APP'},
+            {name: 'setOrientation', context: 'NATIVE_APP'}
         ]);
     }
 
     _exposeWdApi(methods) {
-        var _this = this;
-        methods.forEach(function(method) {
-            _this[method] = function() {
-                return _this._wd[method].apply(_this._wd, arguments);
-            };
-        });
+        methods
+            .map((method) => _.isPlainObject(method) ? method : {name: method})
+            .forEach((method) => this[method.name] = this._exposeWdMethod(method));
+    }
+
+    _exposeWdMethod(method) {
+        return function() {
+            return method.context
+                ? this._applyWdMethodInContext(method.name, method.context, arguments)
+                : this._applyWdMethod(method.name, arguments);
+        };
+    }
+
+    _applyWdMethodInContext(method, context, args) {
+        return this._wd.currentContext()
+            .then((originalContext) => {
+                return this._wd.context(context)
+                    .then(() => this._applyWdMethod(method, args))
+                    .fin(() => this._wd.context(originalContext));
+            });
+    }
+
+    _applyWdMethod(method, args) {
+        return this._wd[method].apply(this._wd, args);
     }
 
     launch(calibrator) {


### PR DESCRIPTION
/cc @sipayRT @tormozz48 

Решил делать не через fallback, так как в этом случае смена ориентации в тесте занимает большое количество времени (смена ориентации выполняется через два метода `wd`: 
1. получение ориентации и 2. смена ориентации на противоположную), то есть при использовании алгоритма с fallback-ом происходит следующее:

1. Пытаемся получить ориентацию в дефолтном контексте и падаем (тратим время, которое выставлено в `httpTimeout`, то есть в общем случае 1 минута, так как вызов методов `getOrientation` и `setOrientation` в `appium@1.4.x` не падает моментально, а падает по таймауту)
2. Получаем ориентацию в контексте `NATIVE_APP`
3. Возвращаем дефолтный контекст
4. Пытаемся сменить ориентацию в дефолтном контексте и падаем (+1 минута)
5. Меняем ориентацию в контексте `NATIVE_APP`
6. Возвращаем дефолтный контекст

В итоге на выполнение теста придется потратить дополнительно 2 минуты + еще 2 минуты (в postActions будет выполнена обратная смена ориентации). Это можно с оптимизировать, но в итоге не получится до конца убрать тот момент, что нам в некоторых случаях приходится ждать *пока мы упадем*.

Исходя из этого было принято решение ВСЕГДА вызываться методы `getOrientation` и `setOrientation` в контексте `NATIVE_APP` до тех пор, пока не оторвем поддержку `appium@1.4.x`. Такой вариант работает и с `appium@1.4.x`, и c `appium@1.5.x`, пользователь ничего заметить не должен, это обычный патч :)