### PR TITLE
Move uglify-js from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sizzle": "^2.2.0",
     "source-map": "^0.5.3",
     "temp": "~0.8.0",
+    "uglify-js": "2.6.4",
     "uglifyify": "^3.0.1",
     "wd": "^0.4.0",
     "worker-farm": "^1.3.1"
@@ -45,14 +46,13 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "coveralls": "^2.11.2",
+    "eslint": "^3.1.1",
+    "eslint-config-gemini-testing": "^2.0.0",
     "husky": "^0.11.4",
     "istanbul": "^0.4.2",
-    "eslint": "^3.0.1",
     "mocha": "^2.1.0",
     "proxyquire": "^1.7.3",
-    "sinon": "^1.17.3",
-    "uglify-js": "2.6.4",
-    "eslint-config-gemini-testing": "^2.0.0"
+    "sinon": "^1.17.3"
   },
   "scripts": {
     "test-unit": "istanbul test _mocha -- --recursive test/unit",


### PR DESCRIPTION
In case when command 'npm i' will be called with parameter '--production'
devDependencies will not be installed and package uglifyify will use his own uglify-js@2.7.0 version