### PR TITLE
Switch on skipped test on 'capture-session'

### DIFF
--- a/test/unit/capture-session/index.js
+++ b/test/unit/capture-session/index.js
@@ -319,7 +319,7 @@ describe('capture session', () => {
                     });
 
                     // Test does not fairly check that `captureViewportImage` was called after resolving of `scrollBy`
-                    it.skip('should capture viewport image after scroll', () => {
+                    it('should capture viewport image after scroll', () => {
                         page = {captureArea: {height: 7}, viewport: {top: 0, height: 5}};
 
                         const scrolledPage = {captureArea: {height: 7}, viewport: {top: 2, height: 5}};


### PR DESCRIPTION
/cc @sipayRT @tormozz48 @j0tunn 

Мы выключали тест, так как он *честно* не проверяет, что один метод был вызван после того как предыдущий **выполнился**. Попытался задать вопрос ребятам из `sinon` –  [issue/1106](https://github.com/sinonjs/sinon/issues/1106). Говорят, что это не их проблема, а проблема библиотеки промисов, которую мы используем. Предложили задать вопрос на [Sinon.JS mailinglist](https://groups.google.com/forum/#!forum/sinonjs), создал [тему](https://groups.google.com/forum/#!topic/sinonjs/cm7PmRQgRXU).

Давайте включим скипнутый тест. С точки зрения здравого смысла этот тест проверяет то, что нам и надо. По факту мы не можем проверить только то, что цепочка промисов не разрывна.