### PR TITLE
Support ie8 while minimize client scripts

### DIFF
--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -223,7 +223,13 @@ module.exports = class NewBrowser extends Browser {
             script.exclude('./gemini.coverage');
         }
 
-        script.transform({sourcemap: false, global: true}, 'uglifyify');
+        script.transform({
+            sourcemap: false,
+            global: true,
+            compress: {screw_ie8: false}, // eslint-disable-line camelcase
+            mangle: {screw_ie8: false}, // eslint-disable-line camelcase
+            output: {screw_ie8: false} // eslint-disable-line camelcase
+        }, 'uglifyify');
         var queryLib = this._needsSizzle ? './query.sizzle.js' : './query.native.js';
         script.transform({
             aliases: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "sizzle": "^2.2.0",
     "source-map": "^0.5.3",
     "temp": "~0.8.0",
-    "uglify-js": "2.6.4",
     "uglifyify": "^3.0.1",
     "wd": "^0.4.0",
     "worker-farm": "^1.3.1"
@@ -52,11 +51,12 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.1.0",
     "proxyquire": "^1.7.3",
-    "sinon": "^1.17.3"
+    "sinon": "^1.17.3",
+    "uglify-js": "^2.7.0"
   },
   "scripts": {
     "test-unit": "istanbul test _mocha -- --recursive test/unit",
-    "prepublish": "uglifyjs ./lib/browser/client-scripts/gemini.calibrate.js -m > ./lib/browser/client-scripts/gemini.calibrate.min.js",
+    "prepublish": "uglifyjs ./lib/browser/client-scripts/gemini.calibrate.js -m > ./lib/browser/client-scripts/gemini.calibrate.min.js --support-ie8",
     "test-func": "istanbul test _mocha test/functional",
     "test-browser": "istanbul test _mocha test/browser",
     "test": "istanbul test _mocha -- --recursive test/unit test/functional test/browser",


### PR DESCRIPTION
API for enable supporting of ie8 is ugly but it works.
So we don't need to freeze uglify-js version