### PR TITLE
Fix paths resolving issue for gemini coverage module

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -48,8 +48,8 @@ module.exports = inherit({
         this._warned[url] = true;
     },
 
-    _urlToFilePath: function(url, rootUrl) {
-        var relPath = url.replace(rootUrl, '').replace(/^\//, '');
+    _urlToFilePath: function(remoteUrl, rootUrl) {
+        var relPath = url.parse(remoteUrl).path.replace(/^\//, '');
         return path.resolve(this.config.system.sourceRoot, relPath);
     },
 


### PR DESCRIPTION
I found issue in lib/coverage.js module when I moved platform url chunk into rootUrl.
Error is in  https://github.com/gemini-testing/gemini/blob/master/lib/coverage.js#L52 row.

Let assume that:
* remote url is `http://some.remote.host:4444/touch-pad.tests/some/path/to/file`
* source root on local filesystem is `/some/local/filepath`

For rootUrl as `http://some.remote.host:4444/` the resolved local file path will be `http://some.remote.host:4444/`

But for rootUrl as `http://some.remote.host:4444/touch-pad.tests` the resolved local file path will be
broken: `/some/local/filepath/some/path/to/file`