### PR TITLE
Resolve root url option. Add coverage.map option

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -116,6 +116,12 @@ settings. These settings can not be set per-browser.
 
   - `enabled` – set to `true` to enable coverage reporting.
 
+  - `map` - function which can be used for overriding default logic of source root path resolving.
+  By default it returns path to CSS file relative to the source root.
+  This function accepts 2 arguments:
+    * `url` - full url of source file which coverage should be obtained
+    * `rootUrl` - root url specified in the config for current browser
+
   - `exclude` – array of file paths or glob patterns to exclude from coverage
     report. For example:
 
@@ -154,7 +160,9 @@ for constructing screens file names.
 Settings list:
 
 * `rootUrl` (required) – the root URL of your website. Target URLs of your
-  test suites will be resolved relatively to it.
+  test suites will be resolved relatively to it. If top level `rootUrl` value is set
+  and browser `rootUrl` - is relative url, then resolved `rootUrl` will be result of
+  concatenation of top level `rootUrl` and individual browser `rootUrl`.
 
 * `desiredCapabilities` (required) - WebDriver
   [DesiredCapabilites](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -1,5 +1,7 @@
 'use strict';
-var _ = require('lodash'),
+
+var url = require('url'),
+    _ = require('lodash'),
     GeminiError = require('../errors/gemini-error'),
     util = require('./util'),
 
@@ -84,7 +86,12 @@ function buildBrowserOptions(defaultFactory, extra) {
     return _.extend(extra, {
         rootUrl: option({
             validate: is('string'),
-            defaultValue: defaultFactory('rootUrl')
+            defaultValue: defaultFactory('rootUrl'),
+            map: (value, config) => {
+                return config.rootUrl && !value.match(/^https?:\/\//)
+                    ? url.resolve(config.rootUrl, value.replace(/^\//, ''))
+                    : value;
+            }
         }),
 
         gridUrl: option({

--- a/lib/config/options.js
+++ b/lib/config/options.js
@@ -59,6 +59,16 @@ module.exports = root(
 
             coverage: section({
                 enabled: booleanOption(false),
+                map: option({
+                    defaultValue: () => {
+                        return (url, rootUrl) => url.replace(rootUrl, '').replace(/^\//, '');
+                    },
+                    validate: (value) => {
+                        if (!_.isFunction(value)) {
+                            throw new GeminiError('"coverage.map" must be a function');
+                        }
+                    }
+                }),
                 exclude: option({
                     defaultValue: [],
                     validate: function(value) {

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -32,7 +32,7 @@ module.exports = inherit({
                 return;
             }
             this.byURL[url] = this.byURL[url] || {
-                sourceFile: this._urlToFilePath(url, this.config.forBrowser(browserId).rootUrl),
+                sourceFile: this._urlToFilePath(url, browserId),
                 coverage: {}
             };
             _.assign(this.byURL[url].coverage, coverage, coverageLevel.merge);
@@ -48,9 +48,12 @@ module.exports = inherit({
         this._warned[url] = true;
     },
 
-    _urlToFilePath: function(url, rootUrl) {
-        var relPath = url.replace(rootUrl, '').replace(/^\//, '');
-        return path.resolve(this.config.system.sourceRoot, relPath);
+    _urlToFilePath: function(url, browserId) {
+        const config = this.config;
+        const rootUrl = config.forBrowser(browserId).rootUrl;
+        const relPath = config.system.coverage.map(url, rootUrl);
+
+        return path.resolve(config.system.sourceRoot, relPath);
     },
 
     processStats: function() {

--- a/test/unit/coverage.js
+++ b/test/unit/coverage.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const _ = require('lodash');
+const path = require('path');
+const Coverage = require('lib/coverage');
+
+describe('coverage', () => {
+    const sandbox = sinon.sandbox.create();
+
+    const createConfig = (opts) => {
+        return _.defaultsDeep(opts || {}, {
+            forBrowser: sinon.stub().returns({
+                rootUrl: 'browser/root/url'
+            }),
+            system: {projectRoot: 'root/path'}
+        });
+    };
+
+    beforeEach(() => {
+        sandbox.stub(path, 'resolve');
+    });
+
+    afterEach(() => sandbox.restore());
+
+    describe('addStatsForBrowser', () => {
+        it('should resolve absolute path to a file on the file system', () => {
+            const config = createConfig({
+                system: {
+                    sourceRoot: 'source/root',
+                    coverage: {map: () => 'rel/path'}
+                }
+            });
+            const coverage = new Coverage(config);
+
+            coverage.addStatsForBrowser({'http://some/url': {}});
+
+            assert.calledWith(path.resolve, 'source/root', 'rel/path');
+        });
+    });
+});


### PR DESCRIPTION
Add ability to use relative `rootUrl` for each browser. In this case common and browser `rootUrl` should concatenate to each other.
Add new option `map` into `coverage` section. This option accept function with can be used for implement custom source path resolving.


Also tests and documentations were added.

@j0tunn @sipayRT @eGavr @RostislavShtanko 