### PR TITLE
Keep original stack when cloning error

### DIFF
--- a/lib/errors/utils.js
+++ b/lib/errors/utils.js
@@ -17,6 +17,7 @@ exports.fromPlainObject = e => {
 
 exports.cloneError = (e) => {
     const clone = new e.constructor(e.message);
+    clone.stack = e.stack;
 
     return _.extend(clone, e);
 };

--- a/test/unit/errors/utils.js
+++ b/test/unit/errors/utils.js
@@ -56,5 +56,12 @@ describe('errors utils', () => {
             const cloned = errorUtils.cloneError(err);
             assert.equal(cloned.key, 'value');
         });
+
+        it('should keep original stack trace when cloning', () => {
+            const err = new Error();
+            const cloned = errorUtils.cloneError(err);
+
+            assert.equal(cloned.stack, err.stack);
+        });
     });
 });


### PR DESCRIPTION
`stack` is not enumerable property, so _.extend does not override it and all cloned errors point to `cloneError` function instead of original. We need to copy the stack manually.

/cc @j0tunn 