### PR TITLE
Node 6 fix up

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "sizzle": "^2.2.0",
     "source-map": "^0.5.3",
     "temp": "~0.8.0",
+    "uglify-js": "^2.7.3",
     "uglifyify": "^3.0.1",
     "wd": "^0.4.0",
     "worker-farm": "^1.3.1"
@@ -52,8 +53,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.1.0",
     "proxyquire": "^1.7.3",
-    "sinon": "^1.17.3",
-    "uglify-js": "^2.7.0"
+    "sinon": "^1.17.3"
   },
   "scripts": {
     "test-unit": "istanbul test _mocha -- --recursive test/unit",


### PR DESCRIPTION
В `npm v3.x`, `uglifyify` использовал `uglify_js v2.3.6`, который лежал в  корне `node_modules` и из-за этого вылетала ошибка. В `uglify-js v2.7.x` все починили, поэтому было решено указать его в `dependencies`, чтобы в корень `node_modules` приезжала именно версия `2.7.x`