### PR TITLE
Add `beforeFileRead`/`afterFileRead` events to API

### DIFF
--- a/doc/programmatic-api.md
+++ b/doc/programmatic-api.md
@@ -215,3 +215,10 @@ plugins:
   be delayed until the promise resolves.
 
 * `endRunner` - emitted after the end of the `test` or `update` command.
+
+* `beforeFileRead` – emitted before each test file is read. The event is emitted
+  with 1 argument `filePath` which is the absolute path to the file to be read.
+
+* `afterFileRead` – emitted after each test file have been read. The event is
+  emitted with 1 argument `filePath` which is the absolute path to the file that
+  was read.

--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -99,7 +99,7 @@ module.exports = class Gemini extends QEmitter {
     }
 
     readTests(paths, grep) {
-        return readTests(paths, this.config)
+        return readTests(paths, this.config, this)
             .then((rootSuite) => {
                 if (grep) {
                     applyGrep_(grep, rootSuite);

--- a/lib/test-reader.js
+++ b/lib/test-reader.js
@@ -43,21 +43,23 @@ const getBrowsers = (file, sets, config) => {
     return _.isEmpty(browsers) ? config.getBrowserIds() : browsers;
 };
 
-const loadSuites = (files, sets, config) => {
+const loadSuites = (files, sets, config, emmiter) => {
     const rootSuite = Suite.create('');
 
     files.forEach((file) => {
         const browsers = getBrowsers(file, sets, config);
 
         global.gemini = testsApi(rootSuite, browsers);
+        emmiter.emit('beforeFileRead', file);
         utils.requireWithNoCache(file);
+        emmiter.emit('afterFileRead', file);
         delete global.gemini;
     });
 
     return rootSuite;
 };
 
-module.exports = (paths, config) => {
+module.exports = (paths, config, emmiter) => {
     return q.all([
         expandSets(config.sets, config.system.projectRoot),
         pathUtils.expandPaths(paths)
@@ -65,6 +67,6 @@ module.exports = (paths, config) => {
     .spread((sets, filesToRun) => {
         const files = _.isEmpty(filesToRun) ? getFiles(sets) : filesToRun;
 
-        return loadSuites(files, sets, config);
+        return loadSuites(files, sets, config, emmiter);
     });
 };


### PR DESCRIPTION
This allows plugins to be notified when gemini is about to read the
file and said file is finished to be read.

/cc @j0tunn 