### PR TITLE
Fix: send CAPTURE event only on new images during update

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,3 +258,7 @@ system:
 
 To use Gemini in your scripts or build tools you can use experimental
 [programmatic API](doc/programmatic-api.md).
+
+## Events
+
+To learn more about all events in Gemini use [events documentation](doc/events.md).

--- a/doc/events.md
+++ b/doc/events.md
@@ -1,8 +1,6 @@
 # Gemini events
 
-Events list:
-
-* `updateResult` - emitted always during update. The event is emitted with 1 argument `result` which contains `refPath` and `updated` fields:
+* `updateResult` - emitted always during update. The event is emitted with 1 argument `result`:
 
     * `result.refPath` - absolute path to the reference image
     * `result.updated` - boolean value which is `true` when reference image have been changed and `false` when not

--- a/doc/events.md
+++ b/doc/events.md
@@ -1,0 +1,8 @@
+# Gemini events
+
+Events list:
+
+* `updateResult` - emitted always during update. The event is emitted with 1 argument `result` which contains `refPath` and `updated` fields:
+
+    * `result.refPath` - absolute path to the reference image
+    * `result.updated` - boolean value which is `true` when reference image have been changed and `false` when not

--- a/doc/events.md
+++ b/doc/events.md
@@ -2,5 +2,5 @@
 
 * `updateResult` - emitted always during update. The event is emitted with 1 argument `result`:
 
-    * `result.refPath` - absolute path to the reference image
+    * `result.imagePath` - absolute path to the reference image
     * `result.updated` - boolean value which is `true` when reference image have been changed and `false` when not

--- a/lib/constants/runner-events.js
+++ b/lib/constants/runner-events.js
@@ -27,5 +27,6 @@ module.exports = {
     ERROR: 'err', // unable to call it `error` because `error` handling is a special case for EventEmitter
 
     END_TEST: 'endTest',
-    CAPTURE: 'capture'
+    CAPTURE: 'capture',
+    END_CAPTURE: 'endCapture'
 };

--- a/lib/constants/runner-events.js
+++ b/lib/constants/runner-events.js
@@ -27,7 +27,7 @@ module.exports = {
     ERROR: 'err', // unable to call it `error` because `error` handling is a special case for EventEmitter
 
     END_TEST: 'endTest',
-    CAPTURE: 'capture',
+    CAPTURE: 'capture', // Deprecated, will be removed in the next major version - 5.0.0
 
     UPDATE_RESULT: 'updateResult'
 };

--- a/lib/constants/runner-events.js
+++ b/lib/constants/runner-events.js
@@ -28,5 +28,6 @@ module.exports = {
 
     END_TEST: 'endTest',
     CAPTURE: 'capture',
-    END_CAPTURE: 'endCapture'
+
+    UPDATE_RESULT: 'updateResult'
 };

--- a/lib/reporters/flat-factory/flat-verbose.js
+++ b/lib/reporters/flat-factory/flat-verbose.js
@@ -1,11 +1,10 @@
 'use strict';
 
-var Flat = require('./flat'),
-    inherit = require('inherit');
+const Flat = require('./flat');
 
-module.exports = inherit(Flat, {
-    _formatStateInfo: function(result) {
-        var tmpl = result.state
+module.exports = class FlatVerbose extends Flat {
+    _formatStateInfo(result) {
+        const tmpl = result.state
             ? ' ${state} ${chalk.underline(name)} [${chalk.yellow(bId)}: ${chalk.blue(sId)}]'
             : ' ${state} [${chalk.yellow(bId)}: ${chalk.blue(sId)}]';
 
@@ -16,4 +15,4 @@ module.exports = inherit(Flat, {
             sId: result.sessionId || 'unknown session id'
         });
     }
-});
+};

--- a/lib/reporters/flat-factory/flat.js
+++ b/lib/reporters/flat-factory/flat.js
@@ -51,17 +51,17 @@ module.exports = class Flat {
     }
 
     _onUpdateResult(result) {
-        const handler = result.updated ? this._onCapture : this._onNotUpdateResult;
+        const handler = result.updated ? this._onCapture : this._onNoCapture;
         handler.call(this, result);
-    }
-
-    _onNotUpdateResult(result) {
-        logger.log(ICON_NOT_UPDATED + this._formatStateInfo(result));
-        this._counter.onPassed(result);
     }
 
     _onCapture(result) {
         logger.log(ICON_SUCCESS + this._formatStateInfo(result));
+        this._counter.onPassed(result);
+    }
+
+    _onNoCapture(result) {
+        logger.log(ICON_NOT_UPDATED + this._formatStateInfo(result));
         this._counter.onPassed(result);
     }
 

--- a/lib/reporters/flat-factory/flat.js
+++ b/lib/reporters/flat-factory/flat.js
@@ -1,86 +1,97 @@
 'use strict';
 
-var inherit = require('inherit'),
-    _ = require('lodash'),
-    chalk = require('chalk'),
-    logger = require('../../utils').logger,
-    TestCounter = require('../utils/test-counter'),
+const _ = require('lodash');
+const chalk = require('chalk');
 
-    RunnerEvents = require('../../constants/runner-events'),
+const logger = require('../../utils').logger;
+const TestCounter = require('../utils/test-counter');
 
-    ICON_SUCCESS = chalk.green('\u2713'),
-    ICON_FAIL = chalk.red('\u2718'),
-    ICON_WARN = chalk.bold.yellow('!'),
-    ICON_RETRY = chalk.yellow('⟳');
+const RunnerEvents = require('../../constants/runner-events');
 
-module.exports = inherit({
-    __constructor: function() {
+const ICON_SUCCESS = chalk.green('\u2713');
+const ICON_FAIL = chalk.red('\u2718');
+const ICON_WARN = chalk.bold.yellow('!');
+const ICON_RETRY = chalk.yellow('⟳');
+const ICON_NOT_UPDATED = chalk.gray('\u2713');
+
+module.exports = class Flat {
+    constructor() {
         this._counter = new TestCounter();
-    },
+    }
 
-    attachRunner: function(runner) {
+    attachRunner(runner) {
         runner.on(RunnerEvents.END_TEST, this._onEndTest.bind(this));
         runner.on(RunnerEvents.RETRY, this._onRetry.bind(this));
-        runner.on(RunnerEvents.CAPTURE, this._onCapture.bind(this));
+        runner.on(RunnerEvents.UPDATE_RESULT, this._onUpdateResult.bind(this));
         runner.on(RunnerEvents.ERROR, this._onError.bind(this));
         runner.on(RunnerEvents.WARNING, this._onWarning.bind(this));
         runner.on(RunnerEvents.END, this._onEnd.bind(this));
         runner.on(RunnerEvents.INFO, this._onInfo.bind(this));
         runner.on(RunnerEvents.SKIP_STATE, this._onSkipState.bind(this));
-    },
+    }
 
-    _compile: function(tmpl, data) {
+    _compile(tmpl, data) {
         return _.template(tmpl, {
             imports: {
                 chalk: chalk
             }
         })(data);
-    },
+    }
 
-    _onEndTest: function(result) {
-        var handler = result.equal ? this._onCapture : this._onError;
+    _onEndTest(result) {
+        const handler = result.equal ? this._onCapture : this._onError;
         handler.call(this, result);
-    },
+    }
 
-    _onRetry: function(result) {
+    _onRetry(result) {
         logger.log(ICON_RETRY + this._formatRetryInfo(result));
         this._logError(result);
 
         this._counter.onRetry(result);
-    },
+    }
 
-    _onCapture: function(result) {
+    _onUpdateResult(result) {
+        const handler = result.updated ? this._onCapture : this._onNotUpdateResult;
+        handler.call(this, result);
+    }
+
+    _onNotUpdateResult(result) {
+        logger.log(ICON_NOT_UPDATED + this._formatStateInfo(result));
+        this._counter.onPassed(result);
+    }
+
+    _onCapture(result) {
         logger.log(ICON_SUCCESS + this._formatStateInfo(result));
         this._counter.onPassed(result);
-    },
+    }
 
-    _onError: function(result) {
+    _onError(result) {
         logger.log(ICON_FAIL + this._formatStateInfo(result));
         this._logError(result);
 
         this._counter.onFailed(result);
-    },
+    }
 
-    _onWarning: function(result) {
+    _onWarning(result) {
         logger.log(ICON_WARN + this._formatStateInfo(result));
         logger.warn(result.message);
 
         this._counter.onSkipped(result);
-    },
+    }
 
-    _onSkipState: function(result) {
+    _onSkipState(result) {
         logger.log(ICON_WARN + this._formatStateInfo(result)
             + (result.suite.skipComment ? chalk.yellow(' reason: ' + result.suite.skipComment) : ''));
 
         this._counter.onSkipped(result);
-    },
+    }
 
-    _onInfo: function(result) {
+    _onInfo(result) {
         logger.warn(result.message);
-    },
+    }
 
-    _onEnd: function() {
-        var result = this._counter.getResult();
+    _onEnd() {
+        const result = this._counter.getResult();
 
         logger.log('Total: %s Passed: %s Failed: %s Skipped: %s Retries: %s',
             chalk.underline(result.total),
@@ -89,9 +100,9 @@ module.exports = inherit({
             chalk.cyan(result.skipped),
             chalk.cyan(result.retries)
         );
-    },
+    }
 
-    _logError: function(result) {
+    _logError(result) {
         if (result.message) {
             logger.error(result.message);
         }
@@ -99,19 +110,19 @@ module.exports = inherit({
         if (result.originalError && result.originalError.stack) {
             logger.error(result.originalError.stack);
         }
-    },
+    }
 
-    _formatRetryInfo: function(result) {
-        var tmpl = '${stateInfo} will be retried. Retries left: ${chalk.yellow(retriesLeft)}';
+    _formatRetryInfo(result) {
+        const tmpl = '${stateInfo} will be retried. Retries left: ${chalk.yellow(retriesLeft)}';
 
         return this._compile(tmpl, {
             stateInfo: this._formatStateInfo(result),
             retriesLeft: result.retriesLeft
         });
-    },
+    }
 
-    _formatStateInfo: function(result) {
-        var tmpl = result.state
+    _formatStateInfo(result) {
+        const tmpl = result.state
             ? ' ${state} ${chalk.underline(name)} [${chalk.yellow(id)}]'
             : ' ${state} [${chalk.yellow(id)}]';
 
@@ -121,4 +132,4 @@ module.exports = inherit({
             id: result.browserId
         });
     }
-});
+};

--- a/lib/reporters/flat-factory/flat.js
+++ b/lib/reporters/flat-factory/flat.js
@@ -8,11 +8,11 @@ const TestCounter = require('../utils/test-counter');
 
 const RunnerEvents = require('../../constants/runner-events');
 
-const ICON_SUCCESS = chalk.green('\u2713');
-const ICON_FAIL = chalk.red('\u2718');
+const ICON_SUCCESS = chalk.green('✓');
+const ICON_NOT_UPDATED = chalk.gray('✓');
+const ICON_FAIL = chalk.red('✘');
 const ICON_WARN = chalk.bold.yellow('!');
 const ICON_RETRY = chalk.yellow('⟳');
-const ICON_NOT_UPDATED = chalk.gray('\u2713');
 
 module.exports = class Flat {
     constructor() {

--- a/lib/reporters/flat-factory/index.js
+++ b/lib/reporters/flat-factory/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var Flat = require('./flat'),
-    FlatVerbose = require('./flat-verbose');
+const Flat = require('./flat');
+const FlatVerbose = require('./flat-verbose');
+
+const make = (Ctr) => {
+    return (runner) => {
+        const reporter = new Ctr();
+        reporter.attachRunner(runner);
+    };
+};
 
 module.exports = {
     mkFlat: make(Flat),
     mkFlatVerbose: make(FlatVerbose)
 };
-
-function make(Ctr) {
-    return function(runner) {
-        var reporter = new Ctr();
-        reporter.attachRunner(runner);
-    };
-}

--- a/lib/runner/browser-runner/index.js
+++ b/lib/runner/browser-runner/index.js
@@ -83,9 +83,10 @@ var BrowserRunner = inherit(Runner, {
             RunnerEvents.SKIP_STATE,
             RunnerEvents.BEGIN_STATE,
             RunnerEvents.END_STATE,
+            RunnerEvents.END_TEST,
+            RunnerEvents.CAPTURE,
             RunnerEvents.WARNING,
-            RunnerEvents.ERROR,
-            PrivateEvents.STATE_RESULT
+            RunnerEvents.ERROR
         ]);
 
         this._suiteRunners.push(runner);

--- a/lib/runner/browser-runner/index.js
+++ b/lib/runner/browser-runner/index.js
@@ -85,6 +85,7 @@ var BrowserRunner = inherit(Runner, {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
+            RunnerEvents.END_CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR
         ]);

--- a/lib/runner/browser-runner/index.js
+++ b/lib/runner/browser-runner/index.js
@@ -85,7 +85,7 @@ var BrowserRunner = inherit(Runner, {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
-            RunnerEvents.END_CAPTURE,
+            RunnerEvents.UPDATE_RESULT,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR
         ]);

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -70,6 +70,7 @@ module.exports = class TestsRunner extends Runner {
 
         sessionRunner.on(RunnerEvents.END_TEST, (result) => this._handleEndTest(result));
         sessionRunner.on(RunnerEvents.CAPTURE, (result) => this._handleCapture(result));
+        sessionRunner.on(RunnerEvents.END_CAPTURE, (result) => this._handleEndCapture(result));
         sessionRunner.on(RunnerEvents.ERROR, (error) => this._handleError(error));
         sessionRunner.on(PrivateEvents.CRITICAL_ERROR, (error) => this._handleCriticalError(error));
 
@@ -93,6 +94,11 @@ module.exports = class TestsRunner extends Runner {
     _handleCapture(result) {
         this._saveCoverage(result);
         this.emit(RunnerEvents.CAPTURE, result);
+    }
+
+    _handleEndCapture(result) {
+        this._saveCoverage(result);
+        this.emit(RunnerEvents.END_CAPTURE, result);
     }
 
     _saveCoverage(data) {

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -70,7 +70,7 @@ module.exports = class TestsRunner extends Runner {
 
         sessionRunner.on(RunnerEvents.END_TEST, (result) => this._handleEndTest(result));
         sessionRunner.on(RunnerEvents.CAPTURE, (result) => this._handleCapture(result));
-        sessionRunner.on(RunnerEvents.END_CAPTURE, (result) => this._handleEndCapture(result));
+        sessionRunner.on(RunnerEvents.UPDATE_RESULT, (result) => this._handleUpdateResult(result));
         sessionRunner.on(RunnerEvents.ERROR, (error) => this._handleError(error));
         sessionRunner.on(PrivateEvents.CRITICAL_ERROR, (error) => this._handleCriticalError(error));
 
@@ -96,9 +96,9 @@ module.exports = class TestsRunner extends Runner {
         this.emit(RunnerEvents.CAPTURE, result);
     }
 
-    _handleEndCapture(result) {
+    _handleUpdateResult(result) {
         this._saveCoverage(result);
-        this.emit(RunnerEvents.END_CAPTURE, result);
+        this.emit(RunnerEvents.UPDATE_RESULT, result);
     }
 
     _saveCoverage(data) {

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -68,9 +68,10 @@ module.exports = class TestsRunner extends Runner {
             RunnerEvents.WARNING
         ]);
 
+        sessionRunner.on(RunnerEvents.END_TEST, (result) => this._handleEndTest(result));
+        sessionRunner.on(RunnerEvents.CAPTURE, (result) => this._handleCapture(result));
         sessionRunner.on(RunnerEvents.ERROR, (error) => this._handleError(error));
         sessionRunner.on(PrivateEvents.CRITICAL_ERROR, (error) => this._handleCriticalError(error));
-        sessionRunner.on(PrivateEvents.STATE_RESULT, (result) => this._handleStateResult(result));
 
         const suites = suiteCollection.allSuites();
         return sessionRunner.run(suites, this._stateProcessor)
@@ -81,13 +82,22 @@ module.exports = class TestsRunner extends Runner {
         return this._stateProcessor.prepare(this);
     }
 
-    _handleStateResult(result) {
-        if (this.coverage) {
-            this.coverage.addStatsForBrowser(result.coverage, result.browserId);
-        }
+    _handleEndTest(result) {
+        this._saveCoverage(result);
 
         if (!this._failCollector.tryToSubmitStateResult(result)) {
-            this.emit(this._stateProcessor.jobDoneEvent, result);
+            this.emit(RunnerEvents.END_TEST, result);
+        }
+    }
+
+    _handleCapture(result) {
+        this._saveCoverage(result);
+        this.emit(RunnerEvents.CAPTURE, result);
+    }
+
+    _saveCoverage(data) {
+        if (this.coverage) {
+            this.coverage.addStatsForBrowser(data.coverage, data.browserId);
         }
     }
 

--- a/lib/runner/private-events.js
+++ b/lib/runner/private-events.js
@@ -1,6 +1,5 @@
 'use strict';
 
 module.exports = {
-    STATE_RESULT: 'stateResult',
     CRITICAL_ERROR: 'criticalError'
 };

--- a/lib/runner/state-runner/disabled-state-runner.js
+++ b/lib/runner/state-runner/disabled-state-runner.js
@@ -1,13 +1,10 @@
 'use strict';
 
-var q = require('q'),
-    inherit = require('inherit'),
-    StateRunner = require('./state-runner');
+const q = require('q');
+const StateRunner = require('./state-runner');
 
-var DisabledStateRunner = inherit(StateRunner, {
-    _capture: function() {
+module.exports = class DisabledStateRunner extends StateRunner {
+    _capture() {
         return q.resolve();
     }
-});
-
-module.exports = DisabledStateRunner;
+};

--- a/lib/runner/state-runner/state-runner.js
+++ b/lib/runner/state-runner/state-runner.js
@@ -4,8 +4,7 @@ var inherit = require('inherit'),
     _ = require('lodash'),
     Runner = require('../runner'),
 
-    RunnerEvents = require('../../constants/runner-events'),
-    PrivateEvents = require('../private-events');
+    RunnerEvents = require('../../constants/runner-events');
 
 var StateRunner = inherit(Runner, {
     __constructor: function(state, browserSession, config) {
@@ -23,7 +22,7 @@ var StateRunner = inherit(Runner, {
     run: function(stateProcessor) {
         var _this = this;
 
-        _this.emit(RunnerEvents.BEGIN_STATE, this._stateInfo);
+        this._emit(RunnerEvents.BEGIN_STATE);
 
         var session = this._browserSession;
 
@@ -39,20 +38,19 @@ var StateRunner = inherit(Runner, {
                 return _this._capture(stateProcessor, page);
             })
             .fail(function(e) {
-                _.extend(e, _this._stateInfo);
-
-                return _this.emit(RunnerEvents.ERROR, e);
+                return _this._emit(RunnerEvents.ERROR, e);
             })
             .fin(function() {
-                _this.emit(RunnerEvents.END_STATE, _this._stateInfo);
+                _this._emit(RunnerEvents.END_STATE);
             });
     },
 
+    _emit: function(event, data) {
+        this.emit(event, _.extend(data || {}, this._stateInfo));
+    },
+
     _capture: function(stateProcessor, page) {
-        return stateProcessor.exec(this._state, this._browserSession, page)
-            .then(function(result) {
-                this.emit(PrivateEvents.STATE_RESULT, _.extend(result, this._stateInfo));
-            }.bind(this));
+        return stateProcessor.exec(this._state, this._browserSession, page, this._emit.bind(this));
     }
 });
 

--- a/lib/runner/state-runner/state-runner.js
+++ b/lib/runner/state-runner/state-runner.js
@@ -26,10 +26,8 @@ module.exports = class StateRunner extends Runner {
         const session = this._browserSession;
 
         return session.runActions(this._state.actions)
-            .then(() => session.prepareScreenshot(this._state,
-                {coverage: this._config.isCoverageEnabled()}))
-            .fail((e) => session.extendWithPageScreenshot(e)
-                .thenReject(e))
+            .then(() => session.prepareScreenshot(this._state, {coverage: this._config.isCoverageEnabled()}))
+            .fail((e) => session.extendWithPageScreenshot(e).thenReject(e))
             .then((page) => this._capture(stateProcessor, page))
             .fail((e) => this._emit(RunnerEvents.ERROR, e))
             .fin(() => this._emit(RunnerEvents.END_STATE));

--- a/lib/runner/state-runner/state-runner.js
+++ b/lib/runner/state-runner/state-runner.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var inherit = require('inherit'),
-    _ = require('lodash'),
-    Runner = require('../runner'),
+const _ = require('lodash');
 
-    RunnerEvents = require('../../constants/runner-events');
+const Runner = require('../runner');
+const RunnerEvents = require('../../constants/runner-events');
 
-var StateRunner = inherit(Runner, {
-    __constructor: function(state, browserSession, config) {
+module.exports = class StateRunner extends Runner {
+    constructor(state, browserSession, config) {
+        super();
+
         this._state = state;
         this._browserSession = browserSession;
         this._config = config;
@@ -17,41 +18,28 @@ var StateRunner = inherit(Runner, {
             browserId: browserSession.browser.id,
             sessionId: browserSession.browser.sessionId
         };
-    },
+    }
 
-    run: function(stateProcessor) {
-        var _this = this;
-
+    run(stateProcessor) {
         this._emit(RunnerEvents.BEGIN_STATE);
 
-        var session = this._browserSession;
+        const session = this._browserSession;
 
         return session.runActions(this._state.actions)
-            .then(function() {
-                return session.prepareScreenshot(_this._state, {coverage: _this._config.isCoverageEnabled()});
-            })
-            .fail(function(e) {
-                return session.extendWithPageScreenshot(e)
-                    .thenReject(e);
-            })
-            .then(function(page) {
-                return _this._capture(stateProcessor, page);
-            })
-            .fail(function(e) {
-                return _this._emit(RunnerEvents.ERROR, e);
-            })
-            .fin(function() {
-                _this._emit(RunnerEvents.END_STATE);
-            });
-    },
+            .then(() => session.prepareScreenshot(this._state,
+                {coverage: this._config.isCoverageEnabled()}))
+            .fail((e) => session.extendWithPageScreenshot(e)
+                .thenReject(e))
+            .then((page) => this._capture(stateProcessor, page))
+            .fail((e) => this._emit(RunnerEvents.ERROR, e))
+            .fin(() => this._emit(RunnerEvents.END_STATE));
+    }
 
-    _emit: function(event, data) {
+    _emit(event, data) {
         this.emit(event, _.extend(data || {}, this._stateInfo));
-    },
+    }
 
-    _capture: function(stateProcessor, page) {
+    _capture(stateProcessor, page) {
         return stateProcessor.exec(this._state, this._browserSession, page, this._emit.bind(this));
     }
-});
-
-module.exports = StateRunner;
+};

--- a/lib/runner/suite-runner/decorator-suite-runner.js
+++ b/lib/runner/suite-runner/decorator-suite-runner.js
@@ -22,7 +22,7 @@ module.exports = class DecoratorSuiteRunner extends Runner {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
-            RunnerEvents.END_CAPTURE,
+            RunnerEvents.UPDATE_RESULT,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR

--- a/lib/runner/suite-runner/decorator-suite-runner.js
+++ b/lib/runner/suite-runner/decorator-suite-runner.js
@@ -20,9 +20,10 @@ module.exports = class DecoratorSuiteRunner extends Runner {
             RunnerEvents.BEGIN_STATE,
             RunnerEvents.SKIP_STATE,
             RunnerEvents.END_STATE,
+            RunnerEvents.END_TEST,
+            RunnerEvents.CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
-            PrivateEvents.STATE_RESULT,
             PrivateEvents.CRITICAL_ERROR
         ].forEach((event) => this._decorateEvent(event));
     }

--- a/lib/runner/suite-runner/decorator-suite-runner.js
+++ b/lib/runner/suite-runner/decorator-suite-runner.js
@@ -22,6 +22,7 @@ module.exports = class DecoratorSuiteRunner extends Runner {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
+            RunnerEvents.END_CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR

--- a/lib/runner/suite-runner/regular-suite-runner.js
+++ b/lib/runner/suite-runner/regular-suite-runner.js
@@ -96,9 +96,10 @@ const RegularSuiteRunner = inherit(SuiteRunner, {
             RunnerEvents.SKIP_STATE,
             RunnerEvents.BEGIN_STATE,
             RunnerEvents.END_STATE,
+            RunnerEvents.END_TEST,
+            RunnerEvents.CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
-            PrivateEvents.STATE_RESULT,
             PrivateEvents.CRITICAL_ERROR
         ]);
 

--- a/lib/runner/suite-runner/regular-suite-runner.js
+++ b/lib/runner/suite-runner/regular-suite-runner.js
@@ -98,6 +98,7 @@ const RegularSuiteRunner = inherit(SuiteRunner, {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
+            RunnerEvents.END_CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR

--- a/lib/runner/suite-runner/regular-suite-runner.js
+++ b/lib/runner/suite-runner/regular-suite-runner.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const inherit = require('inherit');
 const _ = require('lodash');
 const q = require('q');
 const promiseUtils = require('q-promise-utils');
@@ -15,27 +14,27 @@ const StateRunner = require('../state-runner');
 
 const cloneError = require('../../errors/utils').cloneError;
 
-const RegularSuiteRunner = inherit(SuiteRunner, {
-    __constructor: function(suite, browserAgent, config) {
-        this.__base(suite, browserAgent);
+module.exports = class RegularSuiteRunner extends SuiteRunner {
+    constructor(suite, browserAgent, config) {
+        super(suite, browserAgent);
+
         this._config = config;
-
         this._session = null;
-    },
+    }
 
-    _doRun: function(stateProcessor) {
+    _doRun(stateProcessor) {
         return this._browserAgent.getBrowser()
             .then((browser) => this._initSession(browser))
             .then(() => this._processStates(stateProcessor))
             .catch((e) => this._passErrorToStates(e))
             .fin(() => this._session && this._browserAgent.freeBrowser(this._session.browser));
-    },
+    }
 
-    _initSession: function(browser) {
+    _initSession(browser) {
         this._session = new CaptureSession(browser);
-    },
+    }
 
-    _passErrorToStates: function(e) {
+    _passErrorToStates(e) {
         return this._suite.states.map((state) => {
             return this.emit(RunnerEvents.ERROR, _.extend(cloneError(e), {
                 suite: state.suite,
@@ -43,17 +42,17 @@ const RegularSuiteRunner = inherit(SuiteRunner, {
                 browserId: this._browserAgent.browserId
             }));
         });
-    },
+    }
 
-    cancel: function() {
+    cancel() {
         this._runStateInSession = this._doNothing;
-    },
+    }
 
-    _doNothing: function() {
+    _doNothing() {
         return q.resolve();
-    },
+    }
 
-    _processStates: function(stateProcessor) {
+    _processStates(stateProcessor) {
         const browser = this._session.browser;
 
         return browser.openRelative(this._suite.url)
@@ -67,29 +66,29 @@ const RegularSuiteRunner = inherit(SuiteRunner, {
                     sessionId: browser.sessionId
                 }));
             });
-    },
+    }
 
-    _runBeforeActions: function() {
+    _runBeforeActions() {
         return this._session.runActions(this._suite.beforeActions);
-    },
+    }
 
-    _runAfterActions: function() {
+    _runAfterActions() {
         return this._session.runActions(this._suite.afterActions);
-    },
+    }
 
-    _runPostActions: function() {
+    _runPostActions() {
         return this._session.runPostActions();
-    },
+    }
 
-    _keepPassedError: function(fn) {
+    _keepPassedError(fn) {
         return (e) => q.when(fn.call(this)).fin(() => q.reject(e));
-    },
+    }
 
-    _runStates: function(stateProcessor) {
+    _runStates(stateProcessor) {
         return promiseUtils.seqMap(this._suite.states, (state) => this._runStateInSession(state, stateProcessor));
-    },
+    }
 
-    _runStateInSession: function(state, stateProcessor) {
+    _runStateInSession(state, stateProcessor) {
         const runner = StateRunner.create(state, this._session, this._config);
 
         this.passthroughEvent(runner, [
@@ -98,7 +97,7 @@ const RegularSuiteRunner = inherit(SuiteRunner, {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
-            RunnerEvents.END_CAPTURE,
+            RunnerEvents.UPDATE_RESULT,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR
@@ -106,6 +105,4 @@ const RegularSuiteRunner = inherit(SuiteRunner, {
 
         return runner.run(stateProcessor);
     }
-});
-
-module.exports = RegularSuiteRunner;
+};

--- a/lib/runner/test-session-runner.js
+++ b/lib/runner/test-session-runner.js
@@ -38,7 +38,7 @@ var TestSessionRunner = inherit(Runner, {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
-            RunnerEvents.END_CAPTURE,
+            RunnerEvents.UPDATE_RESULT,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR

--- a/lib/runner/test-session-runner.js
+++ b/lib/runner/test-session-runner.js
@@ -36,9 +36,10 @@ var TestSessionRunner = inherit(Runner, {
             RunnerEvents.SKIP_STATE,
             RunnerEvents.BEGIN_STATE,
             RunnerEvents.END_STATE,
+            RunnerEvents.END_TEST,
+            RunnerEvents.CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
-            PrivateEvents.STATE_RESULT,
             PrivateEvents.CRITICAL_ERROR
         ]);
 

--- a/lib/runner/test-session-runner.js
+++ b/lib/runner/test-session-runner.js
@@ -38,6 +38,7 @@ var TestSessionRunner = inherit(Runner, {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
+            RunnerEvents.END_CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR

--- a/lib/state-processor/capture-processor/capture-processor.js
+++ b/lib/state-processor/capture-processor/capture-processor.js
@@ -4,8 +4,4 @@ module.exports = class CaptureProcessor {
     exec() {
         throw new Error('Not implemented');
     }
-
-    postprocessResult(result) {
-        return result;
-    }
 };

--- a/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('q-io/fs');
+const q = require('q');
 
 const temp = require('../../../temp');
 const Image = require('../../../image');
@@ -16,17 +17,13 @@ module.exports = class DiffScreenUpdater extends ScreenUpdater {
         const currentPath = temp.path({suffix: '.png'});
 
         return capture.image.save(currentPath)
-            .then(() => Image.compare(currentPath, referencePath, {
-                canHaveCaret: capture.canHaveCaret,
-                tolerance: opts.tolerance,
-                pixelRatio: opts.pixelRatio
-            }))
-            .then((isEqual) => {
-                if (!isEqual) {
-                    fs.copy(currentPath, referencePath);
-                }
-
-                return !isEqual;
-            });
+            .then(() => {
+                return Image.compare(currentPath, referencePath, {
+                    canHaveCaret: capture.canHaveCaret,
+                    tolerance: opts.tolerance,
+                    pixelRatio: opts.pixelRatio
+                });
+            })
+            .then((isEqual) => (isEqual ? q() : fs.copy(currentPath, referencePath)).then(!isEqual));
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('q-io/fs');
-const q = require('q');
 
 const temp = require('../../../temp');
 const Image = require('../../../image');
@@ -17,16 +16,18 @@ module.exports = class DiffScreenUpdater extends ScreenUpdater {
         const currentPath = temp.path({suffix: '.png'});
 
         return capture.image.save(currentPath)
-            .then(() => {
-                return Image.compare(currentPath, referencePath, {
-                    canHaveCaret: capture.canHaveCaret,
-                    tolerance: opts.tolerance,
-                    pixelRatio: opts.pixelRatio
-                });
-            })
+            .then(() => Image.compare(currentPath, referencePath, {
+                canHaveCaret: capture.canHaveCaret,
+                tolerance: opts.tolerance,
+                pixelRatio: opts.pixelRatio
+            }))
             .then((isEqual) => {
-                const copy = isEqual ? q.bind(q) : fs.copy.bind(fs, currentPath, referencePath);
-                return copy().thenResolve(!isEqual);
+                if (isEqual) {
+                    return false;
+                }
+
+                return fs.copy(currentPath, referencePath)
+                    .thenResolve(true);
             });
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var fs = require('q-io/fs'),
-    temp = require('../../../temp'),
+const fs = require('q-io/fs');
 
-    Image = require('../../../image'),
-    ScreenUpdater = require('./screen-updater');
+const temp = require('../../../temp');
+const Image = require('../../../image');
+const ScreenUpdater = require('./screen-updater');
 
 module.exports = class DiffScreenUpdater extends ScreenUpdater {
     _processCapture(capture, opts, isRefExists) {
@@ -12,8 +12,8 @@ module.exports = class DiffScreenUpdater extends ScreenUpdater {
             return false;
         }
 
-        var referencePath = opts.refPath,
-            currentPath = temp.path({suffix: '.png'});
+        const referencePath = opts.refPath;
+        const currentPath = temp.path({suffix: '.png'});
 
         return capture.image.save(currentPath)
             .then(() => Image.compare(currentPath, referencePath, {

--- a/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
@@ -9,24 +9,24 @@ var fs = require('q-io/fs'),
 module.exports = class DiffScreenUpdater extends ScreenUpdater {
     _processCapture(capture, opts, isRefExists) {
         if (!isRefExists) {
-            return;
+            return false;
         }
 
-        var refPath = opts.refPath,
-            tmpPath = temp.path({suffix: '.png'});
+        var referencePath = opts.refPath,
+            currentPath = temp.path({suffix: '.png'});
 
-        return capture.image.save(tmpPath)
-            .then(function() {
-                return Image.compare(tmpPath, refPath, {
-                    canHaveCaret: capture.canHaveCaret,
-                    tolerance: opts.tolerance,
-                    pixelRatio: opts.pixelRatio
-                })
-                    .then(function(isEqual) {
-                        if (!isEqual) {
-                            return fs.copy(tmpPath, refPath);
-                        }
-                    });
-            }.bind(this));
+        return capture.image.save(currentPath)
+            .then(() => Image.compare(currentPath, referencePath, {
+                canHaveCaret: capture.canHaveCaret,
+                tolerance: opts.tolerance,
+                pixelRatio: opts.pixelRatio
+            }))
+            .then((isEqual) => {
+                if (!isEqual) {
+                    fs.copy(currentPath, referencePath);
+                }
+
+                return !isEqual;
+            });
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
@@ -24,6 +24,9 @@ module.exports = class DiffScreenUpdater extends ScreenUpdater {
                     pixelRatio: opts.pixelRatio
                 });
             })
-            .then((isEqual) => (isEqual ? q() : fs.copy(currentPath, referencePath)).then(!isEqual));
+            .then((isEqual) => {
+                const copy = isEqual ? q.bind(q) : fs.copy.bind(fs, currentPath, referencePath);
+                return copy().thenResolve(!isEqual);
+            });
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/index.js
+++ b/lib/state-processor/capture-processor/screen-updater/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var DiffUpdater = require('./diff-screen-updater'),
-    NewUpdater = require('./new-screen-updater'),
-    MetaUpdater = require('./meta-screen-updater');
+const DiffUpdater = require('./diff-screen-updater');
+const NewUpdater = require('./new-screen-updater');
+const MetaUpdater = require('./meta-screen-updater');
 
-exports.create = function(opts) {
+exports.create = (opts) => {
     if (opts.diff && !opts.new) {
         return new DiffUpdater();
     }

--- a/lib/state-processor/capture-processor/screen-updater/meta-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/meta-screen-updater.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var ScreenUpdater = require('./screen-updater'),
-    DiffUpdater = require('./diff-screen-updater'),
-    NewUpdater = require('./new-screen-updater'),
+const q = require('q');
 
-    q = require('q');
+const ScreenUpdater = require('./screen-updater');
+const DiffUpdater = require('./diff-screen-updater');
+const NewUpdater = require('./new-screen-updater');
 
 module.exports = class MetaScreenUpdater extends ScreenUpdater {
     constructor() {

--- a/lib/state-processor/capture-processor/screen-updater/meta-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/meta-screen-updater.js
@@ -4,7 +4,7 @@ var ScreenUpdater = require('./screen-updater'),
     DiffUpdater = require('./diff-screen-updater'),
     NewUpdater = require('./new-screen-updater'),
 
-    util = require('q-promise-utils');
+    q = require('q');
 
 module.exports = class MetaScreenUpdater extends ScreenUpdater {
     constructor() {
@@ -15,9 +15,10 @@ module.exports = class MetaScreenUpdater extends ScreenUpdater {
     }
 
     _processCapture(capture, opts, isRefExists) {
-        return util.sequence([
-            this._diffUpdater._processCapture.bind(this._diffUpdater, capture, opts, isRefExists),
-            this._newUpdater._processCapture.bind(this._newUpdater, capture, opts, isRefExists)
-        ]);
+        return q.all([
+            this._diffUpdater._processCapture(capture, opts, isRefExists),
+            this._newUpdater._processCapture(capture, opts, isRefExists)
+        ])
+        .spread((diffUpdaterRes, newUpdaterRes) => diffUpdaterRes || newUpdaterRes);
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
@@ -7,12 +7,11 @@ var fs = require('q-io/fs'),
 module.exports = class NewScreenUpdater extends ScreenUpdater {
     _processCapture(capture, opts, isRefExists) {
         if (isRefExists) {
-            return;
+            return false;
         }
 
         return fs.makeTree(path.dirname(opts.refPath))
-            .then(function() {
-                return capture.image.save(opts.refPath);
-            });
+            .then(() => capture.image.save(opts.refPath))
+            .then(() => true);
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var fs = require('q-io/fs'),
-    path = require('path'),
-    ScreenUpdater = require('./screen-updater');
+const fs = require('q-io/fs');
+const path = require('path');
+
+const ScreenUpdater = require('./screen-updater');
 
 module.exports = class NewScreenUpdater extends ScreenUpdater {
     _processCapture(capture, opts, isRefExists) {

--- a/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
@@ -13,6 +13,6 @@ module.exports = class NewScreenUpdater extends ScreenUpdater {
 
         return fs.makeTree(path.dirname(opts.refPath))
             .then(() => capture.image.save(opts.refPath))
-            .then(() => true);
+            .thenResolve(true);
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/screen-updater.js
@@ -12,7 +12,7 @@ module.exports = class ScreenUpdater extends CaptureProcessor {
             .then(function(isRefExists) {
                 return _this._processCapture(capture, opts, isRefExists);
             })
-            .thenResolve({imagePath: refPath});
+            .then((updated) => ({imagePath: refPath, updated}));
     }
 
     _processCapture() {

--- a/lib/state-processor/capture-processor/screen-updater/screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/screen-updater.js
@@ -1,17 +1,15 @@
 'use strict';
 
-var fs = require('q-io/fs'),
-    CaptureProcessor = require('../capture-processor');
+const fs = require('q-io/fs');
+
+const CaptureProcessor = require('../capture-processor');
 
 module.exports = class ScreenUpdater extends CaptureProcessor {
     exec(capture, opts) {
-        var refPath = opts.refPath,
-            _this = this;
+        const refPath = opts.refPath;
 
         return fs.exists(refPath)
-            .then(function(isRefExists) {
-                return _this._processCapture(capture, opts, isRefExists);
-            })
+            .then((isRefExists) => this._processCapture(capture, opts, isRefExists))
             .then((updated) => ({imagePath: refPath, updated}));
     }
 

--- a/lib/state-processor/capture-processor/tester.js
+++ b/lib/state-processor/capture-processor/tester.js
@@ -10,50 +10,26 @@ var q = require('q'),
     NoRefImageError = require('../../errors/no-ref-image-error');
 
 module.exports = class Tester extends CaptureProcessor {
-    static create(diffColor) {
-        return new Tester(diffColor);
-    }
-
-    constructor(diffColor) {
-        super();
-
-        this._diffColor = diffColor;
+    static create() {
+        return new Tester();
     }
 
     exec(capture, opts) {
         var referencePath = opts.refPath,
-            tmpPath = temp.path({suffix: '.png'});
+            currentPath = temp.path({suffix: '.png'});
 
-        return capture.image.save(tmpPath)
+        return capture.image.save(currentPath)
             .then(() => fs.exists(referencePath))
             .then(refExists => {
                 if (!refExists) {
-                    return q.reject(new NoRefImageError(referencePath, tmpPath));
+                    return q.reject(new NoRefImageError(referencePath, currentPath));
                 }
             })
-            .then(() => {
-                return [tmpPath, Image.compare(tmpPath, referencePath, {
-                    canHaveCaret: capture.canHaveCaret,
-                    tolerance: opts.tolerance,
-                    pixelRatio: opts.pixelRatio
-                })];
-            })
-            .spread((currentPath, equal) => {
-                return {referencePath, currentPath, equal};
-            });
-    }
-
-    postprocessResult(result, opts) {
-        return _.extend(result, {
-            saveDiffTo: diffPath => {
-                return Image.buildDiff({
-                    reference: result.referencePath,
-                    current: result.currentPath,
-                    diff: diffPath,
-                    diffColor: this._diffColor,
-                    tolerance: opts.tolerance
-                });
-            }
-        });
+            .then(() => Image.compare(currentPath, referencePath, {
+                canHaveCaret: capture.canHaveCaret,
+                tolerance: opts.tolerance,
+                pixelRatio: opts.pixelRatio
+            }))
+            .then((equal) => ({referencePath, currentPath, equal}));
     }
 };

--- a/lib/state-processor/capture-processor/tester.js
+++ b/lib/state-processor/capture-processor/tester.js
@@ -2,7 +2,6 @@
 
 var q = require('q'),
     fs = require('q-io/fs'),
-    _ = require('lodash'),
     temp = require('../../temp'),
 
     CaptureProcessor = require('./capture-processor'),
@@ -20,7 +19,7 @@ module.exports = class Tester extends CaptureProcessor {
 
         return capture.image.save(currentPath)
             .then(() => fs.exists(referencePath))
-            .then(refExists => {
+            .then((refExists) => {
                 if (!refExists) {
                     return q.reject(new NoRefImageError(referencePath, currentPath));
                 }

--- a/lib/state-processor/capture-processor/tester.js
+++ b/lib/state-processor/capture-processor/tester.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var q = require('q'),
-    fs = require('q-io/fs'),
-    temp = require('../../temp'),
+const q = require('q');
+const fs = require('q-io/fs');
 
-    CaptureProcessor = require('./capture-processor'),
-    Image = require('../../image'),
-    NoRefImageError = require('../../errors/no-ref-image-error');
+const temp = require('../../temp');
+const CaptureProcessor = require('./capture-processor');
+const Image = require('../../image');
+const NoRefImageError = require('../../errors/no-ref-image-error');
 
 module.exports = class Tester extends CaptureProcessor {
     static create() {
@@ -14,8 +14,8 @@ module.exports = class Tester extends CaptureProcessor {
     }
 
     exec(capture, opts) {
-        var referencePath = opts.refPath,
-            currentPath = temp.path({suffix: '.png'});
+        const referencePath = opts.refPath;
+        const currentPath = temp.path({suffix: '.png'});
 
         return capture.image.save(currentPath)
             .then(() => fs.exists(referencePath))

--- a/lib/state-processor/index.js
+++ b/lib/state-processor/index.js
@@ -1,21 +1,14 @@
 'use strict';
 
-var StateProcessor = require('./state-processor'),
-    RunnerEvents = require('../constants/runner-events');
-
-function create(captureProcessorName, jobDoneEvent, constructorArg) {
-    return new StateProcessor({
-        module: require.resolve('./capture-processor/' + captureProcessorName),
-        constructorArg
-    }, jobDoneEvent);
-}
+const UpdateStateProcessor = require('./update-state-processor');
+const TestStateProcessor = require('./test-state-processor');
 
 module.exports = {
     createTester: function(config) {
-        return create('tester', RunnerEvents.END_TEST, config.system.diffColor);
+        return new TestStateProcessor(config);
     },
 
     createScreenUpdater: function(options) {
-        return create('screen-updater', RunnerEvents.CAPTURE, options);
+        return new UpdateStateProcessor(options);
     }
 };

--- a/lib/state-processor/job.js
+++ b/lib/state-processor/job.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var CaptureSession = require('../capture-session'),
-    temp = require('../temp');
+const CaptureSession = require('../capture-session');
+const temp = require('../temp');
 
-module.exports = function(args, cb) {
+module.exports = (args, cb) => {
     temp.attach(args.temp);
 
-    var captureProcessor = require(args.captureProcessorInfo.module)
-            .create(args.captureProcessorInfo.constructorArg);
+    const captureProcessor = require(args.captureProcessorInfo.module)
+        .create(args.captureProcessorInfo.constructorArg);
 
     return CaptureSession.fromObject(args.browserSession)
         .then(browserSession => browserSession.capture(args.page))

--- a/lib/state-processor/state-processor.js
+++ b/lib/state-processor/state-processor.js
@@ -8,12 +8,8 @@ var _ = require('lodash'),
     errorUtils = require('../errors/utils');
 
 module.exports = class StateProcessor {
-    constructor(captureProcessorInfo, jobDoneEvent) {
+    constructor(captureProcessorInfo) {
         this._captureProcessorInfo = captureProcessorInfo;
-        this._captureProcessor = require(captureProcessorInfo.module)
-            .create(captureProcessorInfo.constructorArg);
-
-        this.jobDoneEvent = jobDoneEvent;
     }
 
     prepare(emitter) {
@@ -39,9 +35,6 @@ module.exports = class StateProcessor {
 
         return q.nfcall(this._workers, jobArgs)
             .fail(err => q.reject(errorUtils.fromPlainObject(err)))
-            .then(result => {
-                result.coverage = coverage;
-                return this._captureProcessor.postprocessResult(result, jobArgs.execOpts);
-            });
+            .then(result => _.extend(result, {coverage}));
     }
 };

--- a/lib/state-processor/state-processor.js
+++ b/lib/state-processor/state-processor.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var _ = require('lodash'),
-    q = require('q'),
-    workerFarm = require('worker-farm'),
-    temp = require('../temp'),
-    RunnerEvents = require('../constants/runner-events'),
-    errorUtils = require('../errors/utils');
+const _ = require('lodash');
+const q = require('q');
+const workerFarm = require('worker-farm');
+
+const temp = require('../temp');
+const RunnerEvents = require('../constants/runner-events');
+const errorUtils = require('../errors/utils');
 
 module.exports = class StateProcessor {
     constructor(captureProcessorInfo) {
@@ -18,20 +19,20 @@ module.exports = class StateProcessor {
     }
 
     exec(state, browserSession, page) {
-        var coverage = page.coverage,
-            jobArgs = {
-                captureProcessorInfo: this._captureProcessorInfo,
-                browserSession: browserSession.serialize(),
-                page: _.omit(page, 'coverage'),
-                execOpts: {
-                    pixelRatio: page.pixelRatio,
-                    refPath: browserSession.browser.config.getScreenshotPath(state.suite, state.name),
-                    tolerance: _.isNumber(state.tolerance)
-                        ? state.tolerance
-                        : browserSession.browser.config.tolerance
-                },
-                temp: temp.serialize()
-            };
+        const coverage = page.coverage;
+        const jobArgs = {
+            captureProcessorInfo: this._captureProcessorInfo,
+            browserSession: browserSession.serialize(),
+            page: _.omit(page, 'coverage'),
+            execOpts: {
+                pixelRatio: page.pixelRatio,
+                refPath: browserSession.browser.config.getScreenshotPath(state.suite, state.name),
+                tolerance: _.isNumber(state.tolerance)
+                    ? state.tolerance
+                    : browserSession.browser.config.tolerance
+            },
+            temp: temp.serialize()
+        };
 
         return q.nfcall(this._workers, jobArgs)
             .fail(err => q.reject(errorUtils.fromPlainObject(err)))

--- a/lib/state-processor/state-processor.js
+++ b/lib/state-processor/state-processor.js
@@ -20,6 +20,10 @@ module.exports = class StateProcessor {
 
     exec(state, browserSession, page) {
         const coverage = page.coverage;
+        const tolerance = _.isNumber(state.tolerance)
+            ? state.tolerance
+            : browserSession.browser.config.tolerance;
+
         const jobArgs = {
             captureProcessorInfo: this._captureProcessorInfo,
             browserSession: browserSession.serialize(),
@@ -27,15 +31,13 @@ module.exports = class StateProcessor {
             execOpts: {
                 pixelRatio: page.pixelRatio,
                 refPath: browserSession.browser.config.getScreenshotPath(state.suite, state.name),
-                tolerance: _.isNumber(state.tolerance)
-                    ? state.tolerance
-                    : browserSession.browser.config.tolerance
+                tolerance: tolerance
             },
             temp: temp.serialize()
         };
 
         return q.nfcall(this._workers, jobArgs)
             .fail(err => q.reject(errorUtils.fromPlainObject(err)))
-            .then(result => _.extend(result, {coverage}));
+            .then(result => _.extend(result, {coverage, tolerance}));
     }
 };

--- a/lib/state-processor/state-processor.js
+++ b/lib/state-processor/state-processor.js
@@ -31,7 +31,7 @@ module.exports = class StateProcessor {
             execOpts: {
                 pixelRatio: page.pixelRatio,
                 refPath: browserSession.browser.config.getScreenshotPath(state.suite, state.name),
-                tolerance: tolerance
+                tolerance
             },
             temp: temp.serialize()
         };

--- a/lib/state-processor/test-state-processor.js
+++ b/lib/state-processor/test-state-processor.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const StateProcessor = require('./state-processor');
 const RunnerEvents = require('../constants/runner-events');
-const PrivateEvents = require('../runner/private-events');
 const Image = require('../image');
 
 module.exports = class TestStateProcessor extends StateProcessor {
@@ -44,4 +43,4 @@ module.exports = class TestStateProcessor extends StateProcessor {
             }
         });
     }
-}
+};

--- a/lib/state-processor/test-state-processor.js
+++ b/lib/state-processor/test-state-processor.js
@@ -20,28 +20,22 @@ module.exports = class TestStateProcessor extends StateProcessor {
         return super.exec(state, browserSession, page)
             .then((result) => {
                 if (!result.equal) {
-                    result = this._attachDiffBuilder(result, state, browserSession);
+                    result = this._attachDiffBuilder(result);
                 }
 
                 emit(RunnerEvents.END_TEST, result);
             });
     }
 
-    _attachDiffBuilder(result, state, browserSession) {
-        const tolerance = _.isNumber(state.tolerance)
-            ? state.tolerance
-            : browserSession.browser.config.tolerance;
-
+    _attachDiffBuilder(result) {
         return _.extend(result, {
-            saveDiffTo: (diffPath) => {
-                return Image.buildDiff({
-                    reference: result.referencePath,
-                    current: result.currentPath,
-                    diff: diffPath,
-                    diffColor: this._diffColor,
-                    tolerance: tolerance
-                });
-            }
+            saveDiffTo: (diffPath) => Image.buildDiff({
+                reference: result.referencePath,
+                current: result.currentPath,
+                diff: diffPath,
+                diffColor: this._diffColor,
+                tolerance: result.tolerance
+            })
         });
     }
 };

--- a/lib/state-processor/test-state-processor.js
+++ b/lib/state-processor/test-state-processor.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+
 const StateProcessor = require('./state-processor');
 const RunnerEvents = require('../constants/runner-events');
 const Image = require('../image');

--- a/lib/state-processor/test-state-processor.js
+++ b/lib/state-processor/test-state-processor.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const _ = require('lodash');
+const StateProcessor = require('./state-processor');
+const RunnerEvents = require('../constants/runner-events');
+const PrivateEvents = require('../runner/private-events');
+const Image = require('../image');
+
+module.exports = class TestStateProcessor extends StateProcessor {
+    constructor(config) {
+        super({
+            module: require.resolve('./capture-processor/tester'),
+            constructorArg: config.system.diffColor
+        });
+
+        this._diffColor = config.system.diffColor;
+    }
+
+    exec(state, browserSession, page, emit) {
+        return super.exec(state, browserSession, page)
+            .then((result) => {
+                if (!result.equal) {
+                    result = this._attachDiffBuilder(result, state, browserSession);
+                }
+
+                emit(RunnerEvents.END_TEST, result);
+            });
+    }
+
+    _attachDiffBuilder(result, state, browserSession) {
+        const tolerance = _.isNumber(state.tolerance)
+            ? state.tolerance
+            : browserSession.browser.config.tolerance;
+
+        return _.extend(result, {
+            saveDiffTo: (diffPath) => {
+                return Image.buildDiff({
+                    reference: result.referencePath,
+                    current: result.currentPath,
+                    diff: diffPath,
+                    diffColor: this._diffColor,
+                    tolerance: tolerance
+                });
+            }
+        });
+    }
+}

--- a/lib/state-processor/update-state-processor.js
+++ b/lib/state-processor/update-state-processor.js
@@ -2,7 +2,6 @@
 
 const StateProcessor = require('./state-processor');
 const RunnerEvents = require('../constants/runner-events');
-const PrivateEvents = require('../runner/private-events');
 
 module.exports = class UpdateStateProcessor extends StateProcessor {
     constructor(options) {
@@ -16,6 +15,7 @@ module.exports = class UpdateStateProcessor extends StateProcessor {
         return super.exec(state, browserSession, page)
             .then((result) => {
                 emit(RunnerEvents.CAPTURE, result);
+                emit(RunnerEvents.END_CAPTURE, result);
             });
     }
-}
+};

--- a/lib/state-processor/update-state-processor.js
+++ b/lib/state-processor/update-state-processor.js
@@ -15,7 +15,7 @@ module.exports = class UpdateStateProcessor extends StateProcessor {
         return super.exec(state, browserSession, page)
             .then((result) => {
                 emit(RunnerEvents.CAPTURE, result);
-                emit(RunnerEvents.END_CAPTURE, result);
+                emit(RunnerEvents.UPDATE_RESULT, result);
             });
     }
 };

--- a/lib/state-processor/update-state-processor.js
+++ b/lib/state-processor/update-state-processor.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const StateProcessor = require('./state-processor');
+const RunnerEvents = require('../constants/runner-events');
+const PrivateEvents = require('../runner/private-events');
+
+module.exports = class UpdateStateProcessor extends StateProcessor {
+    constructor(options) {
+        super({
+            module: require.resolve('./capture-processor/screen-updater'),
+            constructorArg: options
+        });
+    }
+
+    exec(state, browserSession, page, emit) {
+        return super.exec(state, browserSession, page)
+            .then((result) => {
+                emit(RunnerEvents.CAPTURE, result);
+            });
+    }
+}

--- a/test/unit/reporters/flat/flat-verbose.js
+++ b/test/unit/reporters/flat/flat-verbose.js
@@ -1,30 +1,31 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter,
-    FlatVerboseReporter = require('lib/reporters/flat-factory/flat-verbose'),
-    RunnerEvents = require('lib/constants/runner-events'),
-    logger = require('lib/utils').logger,
-    chalk = require('chalk');
+const chalk = require('chalk');
 
-describe('Reporter#FlatVerbose', function() {
-    var sandbox = sinon.sandbox.create(),
-        emitter;
+const EventEmitter = require('events').EventEmitter;
+const FlatVerboseReporter = require('lib/reporters/flat-factory/flat-verbose');
+const RunnerEvents = require('lib/constants/runner-events');
+const logger = require('lib/utils').logger;
 
-    beforeEach(function() {
-        var reporter = new FlatVerboseReporter();
+describe('Reporter#FlatVerbose', () => {
+    const sandbox = sinon.sandbox.create();
+    let emitter;
+
+    beforeEach(() => {
+        const reporter = new FlatVerboseReporter();
 
         emitter = new EventEmitter();
         reporter.attachRunner(emitter);
         sandbox.stub(logger);
     });
 
-    afterEach(function() {
+    afterEach(() => {
         sandbox.restore();
         emitter.removeAllListeners();
     });
 
-    it('should correctly do the rendering', function() {
-        var test = {
+    it('should correctly do the rendering', () => {
+        const test = {
             suite: {path: ['block', 'size', 'big']},
             state: {name: 'hover'},
             browserId: 'chrome',
@@ -32,10 +33,10 @@ describe('Reporter#FlatVerbose', function() {
         };
 
         emitter.emit(RunnerEvents.BEGIN);
-        emitter.emit(RunnerEvents.CAPTURE, test);
+        emitter.emit(RunnerEvents.UPDATE_RESULT, test);
         emitter.emit(RunnerEvents.END);
 
-        var deserealizedResult = chalk
+        const deserealizedResult = chalk
             .stripColor(logger.log.firstCall.args[0])
             .substr(2); // remove first symbol (icon)
 

--- a/test/unit/reporters/flat/flat.js
+++ b/test/unit/reporters/flat/flat.js
@@ -1,35 +1,34 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter,
-    FlatReporter = require('lib/reporters/flat-factory/flat'),
-    RunnerEvents = require('lib/constants/runner-events'),
-    logger = require('lib/utils').logger,
-    chalk = require('chalk');
+const EventEmitter = require('events').EventEmitter;
+const FlatReporter = require('lib/reporters/flat-factory/flat');
+const RunnerEvents = require('lib/constants/runner-events');
+const logger = require('lib/utils').logger;
+const chalk = require('chalk');
 
-describe('Reporter#Flat', function() {
-    var sandbox = sinon.sandbox.create(),
-        test,
-        emitter;
+describe('Reporter#Flat', () => {
+    const sandbox = sinon.sandbox.create();
 
-    function getCounters(args) {
-        return {
-            total: chalk.stripColor(args[1]),
-            passed: chalk.stripColor(args[2]),
-            failed: chalk.stripColor(args[3]),
-            skipped: chalk.stripColor(args[4]),
-            retries: chalk.stripColor(args[5])
-        };
-    }
+    let test;
+    let emitter;
 
-    function emit(event, data) {
+    const getCounters = (args) => ({
+        total: chalk.stripColor(args[1]),
+        passed: chalk.stripColor(args[2]),
+        failed: chalk.stripColor(args[3]),
+        skipped: chalk.stripColor(args[4]),
+        retries: chalk.stripColor(args[5])
+    });
+
+    const emit = (event, data) => {
         emitter.emit(RunnerEvents.BEGIN);
         if (event) {
             emitter.emit(event, data);
         }
         emitter.emit(RunnerEvents.END);
-    }
+    };
 
-    beforeEach(function() {
+    beforeEach(() => {
         test = {
             suite: {path: []},
             state: {name: 'test'},
@@ -37,22 +36,22 @@ describe('Reporter#Flat', function() {
             retriesLeft: 1
         };
 
-        var reporter = new FlatReporter();
+        const reporter = new FlatReporter();
 
         emitter = new EventEmitter();
         reporter.attachRunner(emitter);
         sandbox.stub(logger);
     });
 
-    afterEach(function() {
+    afterEach(() => {
         sandbox.restore();
         emitter.removeAllListeners();
     });
 
-    it('should initialize counters with 0', function() {
+    it('should initialize counters with 0', () => {
         emit();
 
-        var counters = getCounters(logger.log.lastCall.args);
+        const counters = getCounters(logger.log.lastCall.args);
 
         assert.equal(counters.total, 0);
         assert.equal(counters.passed, 0);
@@ -61,11 +60,11 @@ describe('Reporter#Flat', function() {
         assert.equal(counters.retries, 0);
     });
 
-    describe('should correctly calculate counters for', function() {
-        it('successed', function() {
-            emit(RunnerEvents.CAPTURE, test);
+    describe('should correctly calculate counters for', () => {
+        it('successed', () => {
+            emit(RunnerEvents.UPDATE_RESULT, test);
 
-            var counters = getCounters(logger.log.lastCall.args);
+            const counters = getCounters(logger.log.lastCall.args);
 
             assert.equal(counters.total, 1);
             assert.equal(counters.passed, 1);
@@ -73,10 +72,10 @@ describe('Reporter#Flat', function() {
             assert.equal(counters.skipped, 0);
         });
 
-        it('failed', function() {
+        it('failed', () => {
             emit(RunnerEvents.ERROR, test);
 
-            var counters = getCounters(logger.log.lastCall.args);
+            const counters = getCounters(logger.log.lastCall.args);
 
             assert.equal(counters.total, 1);
             assert.equal(counters.passed, 0);
@@ -84,60 +83,60 @@ describe('Reporter#Flat', function() {
             assert.equal(counters.skipped, 0);
         });
 
-        describe('skipped', function() {
-            it('should increment skipped count on WARNING event', function() {
+        describe('skipped', () => {
+            it('should increment skipped count on WARNING event', () => {
                 emit(RunnerEvents.WARNING, test);
 
-                var counters = getCounters(logger.log.lastCall.args);
+                const counters = getCounters(logger.log.lastCall.args);
 
                 assert.equal(counters.total, 1);
                 assert.equal(counters.skipped, 1);
             });
 
-            it('should increment skipped count on SKIP_STATE event', function() {
+            it('should increment skipped count on SKIP_STATE event', () => {
                 emit(RunnerEvents.SKIP_STATE, test);
 
-                var counters = getCounters(logger.log.lastCall.args);
+                const counters = getCounters(logger.log.lastCall.args);
 
                 assert.equal(counters.total, 1);
                 assert.equal(counters.skipped, 1);
             });
         });
 
-        it('retry', function() {
+        it('retry', () => {
             emit(RunnerEvents.RETRY, test);
 
-            var counters = getCounters(logger.log.lastCall.args);
+            const counters = getCounters(logger.log.lastCall.args);
 
             assert.equal(counters.retries, 1);
         });
     });
 
-    describe('should correctly choose a handler if `equal` is', function() {
-        it('true', function() {
+    describe('should correctly choose a handler if `equal` is', () => {
+        it('true', () => {
             test.equal = true;
 
             emit(RunnerEvents.END_TEST, test);
 
-            var counters = getCounters(logger.log.lastCall.args);
+            const counters = getCounters(logger.log.lastCall.args);
 
             assert.equal(counters.passed, 1);
             assert.equal(counters.failed, 0);
         });
-        it('false', function() {
+        it('false', () => {
             test.equal = false;
 
             emit(RunnerEvents.END_TEST, test);
 
-            var counters = getCounters(logger.log.lastCall.args);
+            const counters = getCounters(logger.log.lastCall.args);
 
             assert.equal(counters.passed, 0);
             assert.equal(counters.failed, 1);
         });
     });
 
-    describe('should print an error if it there is in', function() {
-        it('result', function() {
+    describe('should print an error if it there is in', () => {
+        it('result', () => {
             test.message = 'Error from result';
 
             emit(RunnerEvents.ERROR, test);
@@ -145,7 +144,7 @@ describe('Reporter#Flat', function() {
             assert.calledWith(logger.error, test.message);
         });
 
-        it('originalError', function() {
+        it('originalError', () => {
             test.originalError = {stack: 'Error from originalError'};
 
             emit(RunnerEvents.ERROR, test);
@@ -154,16 +153,16 @@ describe('Reporter#Flat', function() {
         });
     });
 
-    it('should correctly do the rendering', function() {
+    it('should correctly do the rendering', () => {
         test = {
             suite: {path: ['block', 'size', 'big']},
             state: {name: 'hover'},
             browserId: 'chrome'
         };
 
-        emit(RunnerEvents.CAPTURE, test);
+        emit(RunnerEvents.UPDATE_RESULT, test);
 
-        var deserealizedResult = chalk
+        const deserealizedResult = chalk
             .stripColor(logger.log.firstCall.args[0])
             .substr(2); // remove first symbol (icon)
 

--- a/test/unit/runner/index.js
+++ b/test/unit/runner/index.js
@@ -50,7 +50,8 @@ describe('runner', () => {
             const onBegin = sandbox.spy().named('onBegin');
             runner.on('begin', onBegin);
 
-            return run_().then(() => assert.calledOnce(onBegin));
+            return run_()
+                .then(() => assert.calledOnce(onBegin));
         });
 
         it('should pass total number of states when emitting `begin`', () => {
@@ -65,9 +66,8 @@ describe('runner', () => {
             const onBegin = sandbox.spy().named('onBegin');
             runner.on('begin', onBegin);
 
-            return run_(suiteCollectionStub).then(() => {
-                assert.calledWith(onBegin, sinon.match({totalStates: 3}));
-            });
+            return run_(suiteCollectionStub)
+                .then(() => assert.calledWith(onBegin, sinon.match({totalStates: 3})));
         });
 
         it('should pass all browser ids when emitting `begin`', () => {
@@ -110,18 +110,18 @@ describe('runner', () => {
             suiteCollectionStub.allSuites.returns(suites);
             sandbox.stub(testSessionRunner, 'run').returns(q());
 
-            return run_(suiteCollectionStub)
-                .then(() => {
-                    assert.calledOnce(testSessionRunner.run);
-                    assert.calledWith(testSessionRunner.run, suites, stateProcessor);
-                });
+            return run_(suiteCollectionStub).then(() => {
+                assert.calledOnce(testSessionRunner.run);
+                assert.calledWith(testSessionRunner.run, suites, stateProcessor);
+            });
         });
 
         it('should emit `end`', () => {
             const onEnd = sandbox.spy();
             runner.on('end', onEnd);
 
-            return run_().then(() => assert.calledOnce(onEnd));
+            return run_()
+                .then(() => assert.calledOnce(onEnd));
         });
 
         it('should emit events in correct order', () => {
@@ -131,7 +131,8 @@ describe('runner', () => {
             runner.on('begin', begin);
             runner.on('end', end);
 
-            return run_().then(() => assert.callOrder(begin, end));
+            return run_()
+                .then(() => assert.callOrder(begin, end));
         });
 
         describe('retries', () => {
@@ -145,7 +146,8 @@ describe('runner', () => {
             };
 
             const runAndEmit_ = (event, data) => {
-                return run_().then(() => testSessionRunner.emitAndWait(event, data));
+                return run_()
+                    .then(() => testSessionRunner.emitAndWait(event, data));
             };
 
             beforeEach(() => config.forBrowser.returns({retry: Infinity}));
@@ -159,14 +161,16 @@ describe('runner', () => {
                 const onEndTest = sandbox.spy();
                 runner.on('endTest', onEndTest);
 
-                return runAndEmit_('endTest').then(() => assert.calledOnce(onEndTest));
+                return runAndEmit_('endTest')
+                    .then(() => assert.calledOnce(onEndTest));
             });
 
-            it('should emit updateResult event above', () => {
+            it('should pass through updateResult event', () => {
                 const onUpdateResult = sandbox.spy();
                 runner.on('updateResult', onUpdateResult);
 
-                return runAndEmit_('updateResult').then(() => assert.calledOnce(onUpdateResult));
+                return runAndEmit_('updateResult')
+                    .then(() => assert.calledOnce(onUpdateResult));
             });
 
             it('should try to submit non-critical error for retry', () => {

--- a/test/unit/runner/suite-runner/decorator-suite-runner.js
+++ b/test/unit/runner/suite-runner/decorator-suite-runner.js
@@ -68,9 +68,10 @@ describe('runner/suite-runner/decorator-suite-runner', () => {
             RunnerEvents.BEGIN_STATE,
             RunnerEvents.SKIP_STATE,
             RunnerEvents.END_STATE,
+            RunnerEvents.END_TEST,
+            RunnerEvents.CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
-            PrivateEvents.STATE_RESULT,
             PrivateEvents.CRITICAL_ERROR
         ].forEach((event) => {
             it(`should pass ${event} event from an original to a decorated suite runner`, () => {

--- a/test/unit/runner/suite-runner/decorator-suite-runner.js
+++ b/test/unit/runner/suite-runner/decorator-suite-runner.js
@@ -70,6 +70,7 @@ describe('runner/suite-runner/decorator-suite-runner', () => {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
+            RunnerEvents.END_CAPTURE,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR

--- a/test/unit/runner/suite-runner/decorator-suite-runner.js
+++ b/test/unit/runner/suite-runner/decorator-suite-runner.js
@@ -70,7 +70,7 @@ describe('runner/suite-runner/decorator-suite-runner', () => {
             RunnerEvents.END_STATE,
             RunnerEvents.END_TEST,
             RunnerEvents.CAPTURE,
-            RunnerEvents.END_CAPTURE,
+            RunnerEvents.UPDATE_RESULT,
             RunnerEvents.WARNING,
             RunnerEvents.ERROR,
             PrivateEvents.CRITICAL_ERROR

--- a/test/unit/state-processor/capture-processor/screen-updater/diff-screen-updater.test.js
+++ b/test/unit/state-processor/capture-processor/screen-updater/diff-screen-updater.test.js
@@ -35,6 +35,7 @@ describe('diff-screen-updater', () => {
         imageStub.save.returns(q());
 
         fs.exists.returns(q(true));
+        fs.copy.returns(q());
     });
 
     afterEach(() => {

--- a/test/unit/state-processor/capture-processor/screen-updater/meta-screen-updater.test.js
+++ b/test/unit/state-processor/capture-processor/screen-updater/meta-screen-updater.test.js
@@ -35,6 +35,7 @@ describe('meta-screen-updater', () => {
 
         fs.exists.returns(q(true));
         fs.makeTree.returns(q());
+        fs.copy.returns(q());
     });
 
     afterEach(() => {

--- a/test/unit/state-processor/test-state-processor.js
+++ b/test/unit/state-processor/test-state-processor.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const _ = require('lodash');
+const q = require('q');
+
+const CaptureSession = require('lib/capture-session');
+const StateProcessor = require('lib/state-processor/state-processor');
+const TestStateProcessor = require('lib/state-processor/test-state-processor');
+const Image = require('lib/image');
+const util = require('../../util');
+
+describe('state-processor/test-state-processor', () => {
+    const sandbox = sinon.sandbox.create();
+
+    let BrowserSession;
+
+    const mkTestStateProc_ = () => {
+        const config = _.set({}, 'system.diffColor', '#ff00ff');
+        return new TestStateProcessor(config);
+    };
+
+    const exec_ = (opts) => {
+        opts = _.defaultsDeep(opts || {}, {
+            state: util.makeStateStub(),
+            page: {},
+            emit: sinon.spy()
+        });
+
+        return mkTestStateProc_().exec(opts.state, BrowserSession, opts.page, opts.emit);
+    };
+
+    beforeEach(() => {
+        sandbox.stub(StateProcessor.prototype, 'exec');
+        BrowserSession = sinon.createStubInstance(CaptureSession);
+        _.set(BrowserSession, 'browser.config', {});
+    });
+
+    afterEach(() => sandbox.restore());
+
+    describe('exec', () => {
+        it('should call StateProcessor.exec with state, browserSession and page', () => {
+            const state = util.makeStateStub();
+            const page = {};
+
+
+            StateProcessor.prototype.exec.returns(q({}));
+
+            return exec_({state, page})
+                .then(() => {
+                    assert.calledWithExactly(StateProcessor.prototype.exec, state, BrowserSession, page);
+                });
+        });
+
+        it('should emit END_TEST event with atached diff info when images aren\'t equal', () => {
+            const result = {equal: false};
+            const emit = sandbox.stub();
+
+            StateProcessor.prototype.exec.returns(q(result));
+            sandbox.stub(Image, 'buildDiff').returns({diff: 'default/path/diff.png'});
+
+            return exec_({emit})
+                .then(() => {
+                    assert.calledWithExactly(emit, 'endTest', _.extend(result, {saveDiffTo: () => {}}));
+                });
+        });
+
+        it('should emit END_TEST event with diff results when images equal', () => {
+            const result = {equal: true};
+            const emit = sandbox.stub();
+
+            StateProcessor.prototype.exec.returns(q(result));
+
+            return exec_({emit})
+                .then(() => assert.calledWithExactly(emit, 'endTest', result));
+        });
+    });
+});

--- a/test/unit/state-processor/update-state-processor.js
+++ b/test/unit/state-processor/update-state-processor.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const _ = require('lodash');
+const q = require('q');
+
+const CaptureSession = require('lib/capture-session');
+const StateProcessor = require('lib/state-processor/state-processor');
+const UpdateStateProcessor = require('lib/state-processor/update-state-processor');
+const util = require('../../util');
+
+describe('state-processor/update-state-processor', () => {
+    const sandbox = sinon.sandbox.create();
+
+    let BrowserSession;
+
+    const exec_ = (opts) => {
+        opts = _.defaultsDeep(opts || {}, {
+            state: util.makeStateStub(),
+            page: {},
+            emit: sinon.spy()
+        });
+
+        return new UpdateStateProcessor().exec(opts.state, BrowserSession, opts.page, opts.emit);
+    };
+
+    beforeEach(() => {
+        sandbox.stub(StateProcessor.prototype, 'exec');
+        BrowserSession = sinon.createStubInstance(CaptureSession);
+    });
+
+    afterEach(() => sandbox.restore());
+
+    describe('exec', () => {
+        it('should call StateProcessor.exec with state, browserSession and page', () => {
+            const state = util.makeStateStub();
+            const page = {};
+
+            StateProcessor.prototype.exec.returns(q({}));
+
+            return exec_({state, page})
+                .then(() => {
+                    assert.calledWithExactly(StateProcessor.prototype.exec, state, BrowserSession, page);
+                });
+        });
+
+        it('should emit UPDATE_RESULT event with results of updating', () => {
+            const result = {updated: true};
+            const emit = sandbox.stub();
+
+            StateProcessor.prototype.exec.returns(q(result));
+
+            return exec_({emit})
+                .then(() => assert.calledWithExactly(emit, 'updateResult', result));
+        });
+    });
+});

--- a/test/unit/state-processor/update-state-processor.js
+++ b/test/unit/state-processor/update-state-processor.js
@@ -11,40 +11,47 @@ const util = require('../../util');
 describe('state-processor/update-state-processor', () => {
     const sandbox = sinon.sandbox.create();
 
-    let BrowserSession;
-
     const exec_ = (opts) => {
         opts = _.defaultsDeep(opts || {}, {
             state: util.makeStateStub(),
+            browserSession: sinon.createStubInstance(CaptureSession),
             page: {},
             emit: sinon.spy()
         });
 
-        return new UpdateStateProcessor().exec(opts.state, BrowserSession, opts.page, opts.emit);
+        return new UpdateStateProcessor().exec(opts.state, opts.browserSession, opts.page, opts.emit);
     };
 
-    beforeEach(() => {
-        sandbox.stub(StateProcessor.prototype, 'exec');
-        BrowserSession = sinon.createStubInstance(CaptureSession);
-    });
+    beforeEach(() => sandbox.stub(StateProcessor.prototype, 'exec'));
 
     afterEach(() => sandbox.restore());
 
     describe('exec', () => {
-        it('should call StateProcessor.exec with state, browserSession and page', () => {
+        it('should call base class exec method with correct args', () => {
             const state = util.makeStateStub();
             const page = {};
+            const browserSession = sinon.createStubInstance(CaptureSession);
 
             StateProcessor.prototype.exec.returns(q({}));
 
-            return exec_({state, page})
+            return new UpdateStateProcessor().exec(state, browserSession, page, sinon.spy())
                 .then(() => {
-                    assert.calledWithExactly(StateProcessor.prototype.exec, state, BrowserSession, page);
+                    assert.calledWithExactly(StateProcessor.prototype.exec, state, browserSession, page);
                 });
         });
 
-        it('should emit UPDATE_RESULT event with results of updating', () => {
+        it('should emit UPDATE_RESULT event with update results', () => {
             const result = {updated: true};
+            const emit = sandbox.stub();
+
+            StateProcessor.prototype.exec.returns(q(result));
+
+            return exec_({emit})
+                .then(() => assert.calledWithExactly(emit, 'updateResult', result));
+        });
+
+        it('should emit UPDATE_RESULT event with update results even if update image didn\'t occur', () => {
+            const result = {updated: false};
             const emit = sandbox.stub();
 
             StateProcessor.prototype.exec.returns(q(result));


### PR DESCRIPTION
Refactoring:
- Разбил StateProcessor на TestStateProcessor и UpdateStateProcessor, в котором выполняется логика специфичная для каждого типа запуска (test и update)
- Удалил PrivateEvents.STATE_RESULT, теперь StateProcessor'ы сами кидают необходимое событие 