### PR TITLE
Fix error which led to collision of suites in case of empty suite name

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -35,7 +35,7 @@ gemini.suite('button', function(suite) {
 Arguments of a `gemini.suite`:
 
 * `name` – the name of the new test suite. Name is displayed in reports and
-  affects screenshots filenames.
+  affects screenshots filenames. **Important** Name of test suite can not be empty.
 
 * `callback(suite)` – callback, used to set up the suite. Receives a suite
   builder instance (described below).

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -96,6 +96,10 @@ exports.create = function createSuite(name, parent) {
         return new Suite(name);
     }
 
+    if (_.isEmpty(name)) {
+        throw new Error('Empty suite name');
+    }
+
     var suite = Object.create(parent);
     definePrivate(suite);
     suite.name = name;

--- a/test/unit/suite.test.js
+++ b/test/unit/suite.test.js
@@ -61,6 +61,12 @@ describe('suite', function() {
 
             assert.deepEqual(parent.context, {some: 'data'});
         });
+
+        it('should not allow to create suite with empty name', () => {
+            const parent = createSuite('parent');
+
+            assert.throws(() => createSuite('', parent), /Empty suite name/);
+        });
     });
 
     describe('states', function() {

--- a/test/unit/tests-api/suite-builder.js
+++ b/test/unit/tests-api/suite-builder.js
@@ -371,7 +371,7 @@ describe('tests-api/suite-builder', function() {
 
         beforeEach(function() {
             rootSuite = Suite.create('');
-            suite = Suite.create('', rootSuite);
+            suite = Suite.create('some-suite', rootSuite);
             suiteBuilder = new SuiteBuilder(suite);
         });
 


### PR DESCRIPTION
Previous code was changed in [this](https://github.com/gemini-testing/gemini/commit/bfdd6e047ad7d8d1d90698c8e2ce565228fd82ac) commit by @j0tunn with unknown reasons.

I have removed unnecessary _.compact usage for prevent error "Error: No such state `foo` in suite `bar`" appearance. 