### PR TITLE
Fix html report working with non-urlsafe chars

### DIFF
--- a/lib/reporters/html/lib.js
+++ b/lib/reporters/html/lib.js
@@ -11,7 +11,6 @@ var _ = require('lodash'),
 
     absolutePath = _.partial(path.resolve, REPORT_OUT_DIR);
 
-const escapeSpecialChars = (path) => path.split('/').map((item) => encodeURIComponent(item)).join('/');
 
 /**
  * @param {String} kind - одно из значение 'ref', 'current', 'diff'
@@ -24,7 +23,7 @@ function createPath(kind, result) {
     var components = [].concat('images', result.suite.path, result.state.name, result.browserId + '~' + kind + retrySuffix + '.png');
     const pathToImage = path.join.apply(null, components);
 
-    return escapeSpecialChars(pathToImage);
+    return pathToImage;
 }
 
 module.exports = {

--- a/lib/reporters/html/view.js
+++ b/lib/reporters/html/view.js
@@ -11,6 +11,8 @@ var _ = require('lodash'),
 
     makeOutFilePath = _.partial(path.join, REPORT_DIR);
 
+const pathToUrl = (filePath) => filePath.split(path.sep).map((item) => encodeURIComponent(item)).join('/');
+
 Handlebars.registerHelper('section-status', function() {
     if (this.result && this.result.skipped) {
         return 'section_status_skip';
@@ -50,7 +52,8 @@ Handlebars.registerHelper('has-fails', function() {
 });
 
 Handlebars.registerHelper('image', function(kind) {
-    return new Handlebars.SafeString('<img data-src="' + this[kind + 'Path'] + '">');
+    const url = pathToUrl(this[kind + 'Path']);
+    return new Handlebars.SafeString('<img data-src="' + url + '">');
 });
 
 Handlebars.registerHelper('inc', function(value) {

--- a/test/unit/reporters/html/html.test.js
+++ b/test/unit/reporters/html/html.test.js
@@ -3,11 +3,11 @@
 const EventEmitter = require('events').EventEmitter;
 const HtmlReporter = require('lib/reporters/html/index.js');
 const RunnerEvents = require('lib/constants/runner-events');
+const Handlebars = require('handlebars');
 const logger = require('lib/utils').logger;
 const chalk = require('chalk');
 const path = require('path');
 const view = require('lib/reporters/html/view');
-const lib = require('lib/reporters/html/lib');
 
 describe('HTML Reporter', () => {
     const sandbox = sinon.sandbox.create();
@@ -33,17 +33,13 @@ describe('HTML Reporter', () => {
         assert.calledWith(logger.log, `Your HTML report is here: ${chalk.yellow(reportPath)}`);
     });
 
-    it('should escape special chars in paths', () => {
+    it('should escape special chars in urls', () => {
         const data = {
-            suite: {
-                path: 'fake/long+path'
-            },
-            state: {
-                name: 'fakeName'
-            },
-            browserId: 'fakeId'
+            actualPath: 'images/fake/long+path/fakeName/fakeId~current.png'
         };
 
-        assert.equal(lib.currentPath(data), 'images/fake/long%2Bpath/fakeName/fakeId~current.png');
+        const render = Handlebars.compile('{{image "actual"}}');
+
+        assert.equal(render(data), '<img data-src="images/fake/long%2Bpath/fakeName/fakeId~current.png">');
     });
 });


### PR DESCRIPTION
#490 strikes back.
The pull request hasn't actually fixed the problem
For example:
- the suite is named 'foo+bar'
- the path gets escaped and the images in the report will get saved to
  `images/foo%2Bbar/whatever`
- the same path will be used as URL inside report, which means that:
- the browser will unescape the path and look for `images/foo+bar/whatever`,
  won't find it and show sad placeholder image instead.

The fix is:
- move escaping back to view
- do not escape file paths (+ is actually a valid character for a file name).