### PR TITLE
Set left button as default for mouse button actions

### DIFF
--- a/lib/tests-api/actions-builder.js
+++ b/lib/tests-api/actions-builder.js
@@ -98,9 +98,7 @@ module.exports = inherit({
     },
 
     click: function(element, button) {
-        if (isInvalidMouseButton(button)) {
-            throw new TypeError('Mouse button should be 0 (left), 1 (right) or 2 (middle)');
-        }
+        button = acceptMouseButton(button);
 
         if (isInvalidElement(element)) {
             throw new TypeError('.click() must receive valid element or CSS selector');
@@ -119,9 +117,7 @@ module.exports = inherit({
     },
 
     doubleClick: function(element, button) {
-        if (isInvalidMouseButton(button)) {
-            throw new TypeError('Mouse button should be 0 (left), 1 (right) or 2 (middle)');
-        }
+        button = acceptMouseButton(button);
 
         if (isInvalidElement(element)) {
             throw new TypeError('.doubleClick() must receive valid element or CSS selector');
@@ -154,9 +150,7 @@ module.exports = inherit({
     },
 
     mouseDown: function(element, button) {
-        if (isInvalidMouseButton(button)) {
-            throw new TypeError('Mouse button should be 0 (left), 1 (right) or 2 (middle)');
-        }
+        button = acceptMouseButton(button);
 
         if (isInvalidElement(element)) {
             throw new TypeError('.mouseDown() must receive valid element or CSS selector');
@@ -175,9 +169,7 @@ module.exports = inherit({
     },
 
     mouseUp: function(element, button) {
-        if (isInvalidMouseButton(button)) {
-            throw new TypeError('Mouse button should be 0 (left), 1 (right) or 2 (middle)');
-        }
+        button = acceptMouseButton(button);
 
         this._pushAction(this.mouseUp, function mouseUp(browser) {
             var action;
@@ -368,8 +360,16 @@ module.exports = inherit({
     }
 });
 
-function isInvalidMouseButton(button) {
-    return typeof button !== 'undefined' && [0, 1, 2].indexOf(button) === -1;
+function acceptMouseButton(button) {
+    if (typeof button === 'undefined') {
+        return 0;
+    }
+
+    if ([0, 1, 2].indexOf(button) === -1) {
+        throw new TypeError('Mouse button should be 0 (left), 1 (middle) or 2 (right)');
+    }
+
+    return button;
 }
 
 function isInvalidKeys(keys) {

--- a/test/unit/tests-api/actions-builder.js
+++ b/test/unit/tests-api/actions-builder.js
@@ -77,4 +77,115 @@ describe('tests-api/actions-builder', () => {
             return assert.isRejected(changeOrientation(), /awesome error/);
         });
     });
+
+    describe('mouse actions', () => {
+        beforeEach(() => {
+            sandbox.stub(browser, 'moveTo').returns(q());
+            sandbox.stub(browser, 'findElement').returns(q({}));
+        });
+
+        describe('click', () => {
+            beforeEach(() => {
+                sandbox.stub(browser, 'click').returns(q());
+            });
+
+            it('should use left button if not specified', () => {
+                const click = mkAction('click', browser);
+
+                return click('.some-selector')
+                    .then(() => assert.calledWith(browser.click, 0));
+            });
+
+            it('should use passed button', () => {
+                const click = mkAction('click', browser);
+
+                return click('.some-selector', 1)
+                    .then(() => assert.calledWith(browser.click, 1));
+            });
+
+            it('should throw on bad button (not 0, 1 or 2)', () => {
+                const click = mkAction('click', browser);
+
+                assert.throws(() => click('.some-selector', 3), /Mouse button should be/);
+            });
+        });
+
+        describe('doubleClick', () => {
+            beforeEach(() => {
+                sandbox.stub(browser, 'doubleClick').returns(q());
+            });
+
+            it('should use left button if not specified', () => {
+                const doubleClick = mkAction('doubleClick', browser);
+
+                return doubleClick('.some-selector')
+                    .then(() => assert.calledWith(browser.doubleClick, '.some-selector', 0));
+            });
+
+            it('should use passed button', () => {
+                const doubleClick = mkAction('doubleClick', browser);
+
+                return doubleClick('.some-selector', 1)
+                    .then(() => assert.calledWith(browser.doubleClick, '.some-selector', 1));
+            });
+
+            it('should throw on bad button (not 0, 1 or 2)', () => {
+                const doubleClick = mkAction('doubleClick', browser);
+
+                assert.throws(() => doubleClick('.some-selector', 3), /Mouse button should be/);
+            });
+        });
+
+        describe('mouseDown', () => {
+            beforeEach(() => {
+                sandbox.stub(browser, 'buttonDown').returns(q());
+            });
+
+            it('should use left button if not specified', () => {
+                const mouseDown = mkAction('mouseDown', browser);
+
+                return mouseDown('.some-selector')
+                    .then(() => assert.calledWith(browser.buttonDown, 0));
+            });
+
+            it('should use passed button', () => {
+                const mouseDown = mkAction('mouseDown', browser);
+
+                return mouseDown('.some-selector', 1)
+                    .then(() => assert.calledWith(browser.buttonDown, 1));
+            });
+
+            it('should throw on bad button (not 0, 1 or 2)', () => {
+                const mouseDown = mkAction('mouseDown', browser);
+
+                assert.throws(() => mouseDown('.some-selector', 3), /Mouse button should be/);
+            });
+        });
+
+        describe('mouseUp', () => {
+            beforeEach(() => {
+                sandbox.stub(browser, 'buttonUp').returns(q());
+            });
+
+            it('should use left button if not specified', () => {
+                const mouseUp = mkAction('mouseUp', browser);
+
+                return mouseUp('.some-selector')
+                    .then(() => assert.calledWith(browser.buttonUp, 0));
+            });
+
+            it('should use passed button', () => {
+                const mouseUp = mkAction('mouseUp', browser);
+
+                return mouseUp('.some-selector', 1)
+                    .then(() => assert.calledWith(browser.buttonUp, 1));
+            });
+
+            it('should throw on bad button (not 0, 1 or 2)', () => {
+                const mouseUp = mkAction('mouseUp', browser);
+
+                assert.throws(() => mouseUp('.some-selector', 3), /Mouse button should be/);
+            });
+        });
+    });
 });

--- a/test/unit/tests-api/actions-builder.js
+++ b/test/unit/tests-api/actions-builder.js
@@ -9,13 +9,16 @@ describe('tests-api/actions-builder', () => {
     const sandbox = sinon.sandbox.create();
     const browser = util.makeBrowser();
 
-    const createActionsBuilder = (actions) => new ActionsBuilder(actions || []);
+    const mkActionsBuilder = (actions) => new ActionsBuilder(actions || []);
 
-    const runAction = (method, browser, postActions) => {
-        const actions = [];
+    const mkAction = (actionName, browser, postActions) => {
+        return function() {
+            const actions = [];
+            const actionsBuilder = mkActionsBuilder(actions);
 
-        createActionsBuilder(actions)[method]();
-        return actions[0](browser, postActions);
+            actionsBuilder[actionName].apply(actionsBuilder, arguments);
+            return actions[0](browser, postActions);
+        };
     };
 
     afterEach(() => sandbox.restore());
@@ -27,46 +30,51 @@ describe('tests-api/actions-builder', () => {
         });
 
         it('should throw in case of passed arguments', () => {
-            const fn = () => createActionsBuilder().changeOrientation('awesome argument');
+            const fn = () => mkActionsBuilder().changeOrientation('awesome argument');
 
             assert.throws(fn, TypeError, /\.changeOrientation\(\) does not accept any arguments/);
         });
 
         it('should return ActionsBuilder instance', () => {
-            assert.instanceOf(createActionsBuilder().changeOrientation(), ActionsBuilder);
+            assert.instanceOf(mkActionsBuilder().changeOrientation(), ActionsBuilder);
         });
 
         it('should change orientation from PORTRAIT to LANDSCAPE', () => {
             browser.getOrientation.returns(q('PORTRAIT'));
+            const changeOrientation = mkAction('changeOrientation', browser);
 
-            return runAction('changeOrientation', browser)
+            return changeOrientation()
                 .then(() => assert.calledWith(browser.setOrientation, 'LANDSCAPE'));
         });
 
         it('should change orientation from LANDSCAPE to PORTRAIT', () => {
             browser.getOrientation.returns(q('LANDSCAPE'));
+            const changeOrientation = mkAction('changeOrientation', browser);
 
-            return runAction('changeOrientation', browser)
+            return changeOrientation()
                 .then(() => assert.calledWith(browser.setOrientation, 'PORTRAIT'));
         });
 
         it('should restore orientation in post actions', () => {
             const postActions = sinon.createStubInstance(ActionsBuilder);
+            const changeOrientation = mkAction('changeOrientation', browser, postActions);
 
-            return runAction('changeOrientation', browser, postActions)
+            return changeOrientation()
                 .then(() => assert.called(postActions.changeOrientation));
         });
 
         it('should be rejected if getting of orientation fails', () => {
             browser.getOrientation.returns(q.reject('awesome error'));
+            const changeOrientation = mkAction('changeOrientation', browser);
 
-            return assert.isRejected(runAction('changeOrientation', browser), /awesome error/);
+            return assert.isRejected(changeOrientation(), /awesome error/);
         });
 
         it('should be rejected if setting of orientation fails', () => {
             browser.setOrientation.returns(q.reject('awesome error'));
+            const changeOrientation = mkAction('changeOrientation', browser);
 
-            return assert.isRejected(runAction('changeOrientation', browser), /awesome error/);
+            return assert.isRejected(changeOrientation(), /awesome error/);
         });
     });
 });


### PR DESCRIPTION
wd [expects](https://github.com/admc/wd/blob/master/doc/api.md) button to be set for `click`, `doubleClick`, `mouseDown` and `mouseUp` actions.
If we will not set it, then it will be `undefined` and we can get errors like `[click()] Error response status: 400 Selenium error: Missing parameter: button` in case of interaction with webdriver without `Selenium`