### PR TITLE
Add ability to show only diff images in the html-report

### DIFF
--- a/lib/reporters/html/static/report.css
+++ b/lib/reporters/html/static/report.css
@@ -37,10 +37,23 @@
     background: #eee;
 }
 
+.button_checked {
+    background: #ffeba0;
+    border-color: #cebe7d;
+}
+
 .image-box {
     padding: 5px;
     border: 1px solid #ccc;
     background: #c9c9c9;
+}
+
+.image-box__exp-with-act {
+    display: inline-block;
+}
+
+.report_show-only-diff .image-box__exp-with-act {
+    display: none;
 }
 
 .image-box__image {

--- a/lib/reporters/html/static/report.js
+++ b/lib/reporters/html/static/report.js
@@ -99,6 +99,11 @@
         target.closest('.meta-info').classList.toggle('meta-info_collapsed');
     }
 
+    function showOnlyDiff(e) {
+        e.target.classList.toggle('button_checked');
+        document.body.classList.toggle('report_show-only-diff');
+    }
+
     function findClosest(context, cls) {
         while ((context = context.parentNode)) {
             if (context.classList.contains(cls)) {
@@ -126,6 +131,7 @@
         document.getElementById('expandErrors').addEventListener('click', expandErrors);
         document.getElementById('showSkipped').addEventListener('click', showSkippedList);
         document.getElementById('showRetries').addEventListener('click', expandRetries);
+        document.getElementById('showOnlyDiff').addEventListener('click', showOnlyDiff);
         document.body.addEventListener('click', bodyClick);
 
         forEach.call(document.querySelectorAll('.section'), function(section) {

--- a/lib/reporters/html/templates/report.hbs
+++ b/lib/reporters/html/templates/report.hbs
@@ -19,6 +19,7 @@
         <button id="expandErrors" class="button">Expand errors</button>
         <button id="showSkipped" class="button">Show skipped</button>
         <button id="showRetries" class="button">Expand retries</button>
+        <button id="showOnlyDiff" class="button">Show only diff</button>
 
         <div id="skippedList" class="skipped__list collapsed">
             {{#if skips}}

--- a/lib/reporters/html/templates/state.hbs
+++ b/lib/reporters/html/templates/state.hbs
@@ -25,13 +25,15 @@
     </div>
 {{/if}}
 {{#if fail}}
-    <div class="image-box__image">
-        <div class="image-box__title">Expected</div>
-        {{image "expected"}}
-    </div>
-    <div class="image-box__image">
-        <div class="image-box__title">Actual</div>
-        {{image "actual"}}
+    <div class="image-box__exp-with-act">
+        <div class="image-box__image">
+            <div class="image-box__title">Expected</div>
+            {{image "expected"}}
+        </div>
+        <div class="image-box__image">
+            <div class="image-box__title">Actual</div>
+            {{image "actual"}}
+        </div>
     </div>
     <div class="image-box__image">
         <div class="image-box__title">Diff</div>


### PR DESCRIPTION
Show all images (by default): 

<img width="1202" alt="gemini-1" src="https://cloud.githubusercontent.com/assets/1658415/18119712/a52c357e-6f64-11e6-9249-111f937bec92.png">

Show only diffs:

<img width="913" alt="gemini-2" src="https://cloud.githubusercontent.com/assets/1658415/18119724/b1fd6b6a-6f64-11e6-9242-7ea28f081924.png">

