### PR TITLE
Clone suite tree for each browser runner

### DIFF
--- a/lib/reporters/html/view-model.js
+++ b/lib/reporters/html/view-model.js
@@ -1,44 +1,40 @@
 'use strict';
 
-var _ = require('lodash'),
-    inherit = require('inherit'),
-    lib = require('./lib'),
-    TestCounter = require('../utils/test-counter');
+const _ = require('lodash');
+const lib = require('./lib');
+const TestCounter = require('../utils/test-counter');
 
-var NO_STATE = 'NO_STATE';
+const NO_STATE = 'NO_STATE';
 
-module.exports = inherit({
-    /**
-     * @constructor
-     */
-    __constructor: function() {
+module.exports = class ViewModel {
+    constructor() {
         this._tree = {name: 'root'};
         this._skips = [];
         this._counter = new TestCounter();
-    },
+    }
 
     /**
      * @param {StateResult} result
      */
-    addSkipped: function(result) {
+    addSkipped(result) {
         this._addTestResult(result, {
             skipped: true,
             reason: result.suite.skipComment
         });
 
-        var comment = result.suite.skipComment
-            && result.suite.skipComment.replace(/https?:\/\/[^\s]*/g, function(url) {
-                return '<a target="_blank" href="' + url + '">' + url + '</a>';
+        const comment = result.suite.skipComment
+            && result.suite.skipComment.replace(/https?:\/\/[^\s]*/g, (url) => {
+                return `<a target="_blank" href="${url}">${url}</a>`;
             });
-        this._skips.push({suite: result.suite.fullName, browser: result.browserId, comment: comment});
+        this._skips.push({suite: result.suite.fullName, browser: result.browserId, comment});
 
         this._counter.onSkipped(result);
-    },
+    }
 
     /**
      * @param {TestStateResult} result
      */
-    addSuccess: function(result) {
+    addSuccess(result) {
         this._addTestResult(result, {
             success: true,
             actualPath: lib.currentPath(result),
@@ -46,12 +42,12 @@ module.exports = inherit({
         });
 
         this._counter.onPassed(result);
-    },
+    }
 
     /**
      * @param {TestStateResult} result
      */
-    addFail: function(result) {
+    addFail(result) {
         this._addTestResult(result, {
             fail: true,
             actualPath: lib.currentPath(result),
@@ -60,12 +56,12 @@ module.exports = inherit({
         });
 
         this._counter.onFailed(result);
-    },
+    }
 
     /**
      * @param {ErrorStateResult} result
      */
-    addError: function(result) {
+    addError(result) {
         this._addTestResult(result, {
             actualPath: result.state ? lib.currentPath(result) : '',
             error: true,
@@ -74,12 +70,12 @@ module.exports = inherit({
         });
 
         this._counter.onFailed(result);
-    },
+    }
 
     /**
      * @param {WarningStateResult} result
      */
-    addWarning: function(result) {
+    addWarning(result) {
         this._addTestResult(result, {
             warning: true,
             actualPath: lib.currentPath(result),
@@ -87,12 +83,12 @@ module.exports = inherit({
         });
 
         this._counter.onSkipped(result);
-    },
+    }
 
     /**
      * @param {ErrorStateResult|TestStateResult} result
      */
-    addRetry: function(result) {
+    addRetry(result) {
         if (result.hasOwnProperty('equal')) {
             this.addFail(result);
         } else {
@@ -100,39 +96,39 @@ module.exports = inherit({
         }
 
         this._counter.onRetry(result);
-    },
+    }
 
     /**
      * @returns {ViewModelResult}
      */
-    getResult: function() {
+    getResult() {
         return _.extend(this._counter.getResult(), {
             skips: _.uniq(this._skips, JSON.stringify),
             suites: this._tree.children
         });
-    },
+    }
 
-    _addTestResult: function(result, props) {
-        var metaInfo = result.suite ? result.suite.metaInfo : {};
+    _addTestResult(result, props) {
+        const metaInfo = result.suite ? result.suite.metaInfo : {};
         metaInfo.sessionId = result.sessionId || 'unknown session id';
 
-        var testResult = _.assign({
-                name: result.browserId,
-                metaInfo: JSON.stringify(metaInfo, null, 4) || 'Meta info is not available'
-            }, props),
-            node = findOrCreate(this._tree, result.suite.path.concat(result.state ? result.state.name : NO_STATE));
+        const testResult = _.assign({
+            name: result.browserId,
+            metaInfo: JSON.stringify(metaInfo, null, 4) || 'Meta info is not available'
+        }, props);
+        const node = findOrCreate(this._tree, result.suite.path.concat(result.state ? result.state.name : NO_STATE));
 
         node.browsers = Array.isArray(node.browsers) ? node.browsers : [];
 
-        var existing = _.findIndex(node.browsers, {name: testResult.name});
+        const existing = _.findIndex(node.browsers, {name: testResult.name});
 
         if (existing === -1) {
             node.browsers.push({name: testResult.name, result: testResult, retries: []});
             return;
         }
 
-        var stateInBrowser = node.browsers[existing],
-            retry = stateInBrowser.result;
+        const stateInBrowser = node.browsers[existing];
+        const retry = stateInBrowser.result;
 
         // Hack to avoid situations when `testResult` event is emitted several times for a state, for example,
         // when a state passed, but was retried because of a failure of another state in this suite
@@ -143,23 +139,23 @@ module.exports = inherit({
         stateInBrowser.retries.push(retry);
         stateInBrowser.result = testResult;
     }
-}, {
-    hasFails: function hasFails(node) {
-        return walk(node, hasFails, node.result && (node.result.error || node.result.fail));
-    },
 
-    hasWarnings: function hasWarnings(node) {
-        return walk(node, hasWarnings, node.result && node.result.warning);
-    },
-
-    hasRetries: function hasRetries(node) {
-        return walk(node, hasRetries, node.retries && node.retries.length);
+    static hasFails(node) {
+        return walk(node, ViewModel.hasFails, node.result && (node.result.error || node.result.fail));
     }
-});
+
+    static hasWarnings(node) {
+        return walk(node, ViewModel.hasWarnings, node.result && node.result.warning);
+    }
+
+    static hasRetries(node) {
+        return walk(node, ViewModel.hasRetries, node.retries && node.retries.length);
+    }
+};
 
 function walk(node, cb, condition) {
     return ['children', 'browsers'].reduce(function(result, prop) {
-        var collection = node[prop];
+        const collection = node[prop];
         return result || Array.isArray(collection) && collection.some(cb);
     }, condition);
 }
@@ -176,13 +172,13 @@ function findOrCreate(node, statePath) {
 
     node.children = Array.isArray(node.children) ? node.children : [];
 
-    var pathPart = statePath.shift();
+    const pathPart = statePath.shift();
 
     if (pathPart === NO_STATE) {
         return node;
     }
 
-    var child = _.find(node.children, {name: pathPart});
+    let child = _.find(node.children, {name: pathPart});
 
     if (!child) {
         child = {name: pathPart};

--- a/lib/reporters/html/view-model.js
+++ b/lib/reporters/html/view-model.js
@@ -113,7 +113,7 @@ module.exports = inherit({
     },
 
     _addTestResult: function(result, props) {
-        var metaInfo = result.suite ? _.clone(result.suite.metaInfo) : {};
+        var metaInfo = result.suite ? result.suite.metaInfo : {};
         metaInfo.sessionId = result.sessionId || 'unknown session id';
 
         var testResult = _.assign({

--- a/lib/runner/browser-runner/index.js
+++ b/lib/runner/browser-runner/index.js
@@ -22,10 +22,10 @@ var BrowserRunner = inherit(Runner, {
         this._suiteRunners = [];
     },
 
-    run: function(suites, stateProcessor) {
+    run: function(suiteCollection, stateProcessor) {
         log('start browser %s', this._browserId);
         this.emit(RunnerEvents.START_BROWSER, {browserId: this._browserId});
-        return this._runSuites(suites, stateProcessor)
+        return this._runSuites(suiteCollection, stateProcessor)
             .fin(() => {
                 log('stop browser %s', this._browserId);
                 this.emit(RunnerEvents.STOP_BROWSER, {browserId: this._browserId});
@@ -43,8 +43,10 @@ var BrowserRunner = inherit(Runner, {
         return q.resolve();
     },
 
-    _runSuites: function(suites, stateProcessor) {
+    _runSuites: function(suiteCollection, stateProcessor) {
         var _this = this;
+
+        const suites = suiteCollection.clone().allSuites();
 
         return _(suites)
             .filter(function(suite) {

--- a/lib/runner/browser-runner/index.js
+++ b/lib/runner/browser-runner/index.js
@@ -1,28 +1,33 @@
 'use strict';
 
-var inherit = require('inherit'),
-    _ = require('lodash'),
-    q = require('q'),
-    BrowserAgent = require('./browser-agent'),
-    Runner = require('../runner'),
-    SuiteRunner = require('../suite-runner'),
+const _ = require('lodash');
+const q = require('q');
+const BrowserAgent = require('./browser-agent');
+const Runner = require('../runner');
+const SuiteRunner = require('../suite-runner');
 
-    promiseUtils = require('q-promise-utils'),
-    RunnerEvents = require('../../constants/runner-events'),
-    PrivateEvents = require('../private-events'),
-    CancelledError = require('../../errors/cancelled-error'),
+const promiseUtils = require('q-promise-utils');
+const RunnerEvents = require('../../constants/runner-events');
+const PrivateEvents = require('../private-events');
+const CancelledError = require('../../errors/cancelled-error');
 
-    log = require('debug')('gemini:runner');
+const log = require('debug')('gemini:runner');
 
-var BrowserRunner = inherit(Runner, {
-    __constructor: function(browserId, config, browserPool) {
+module.exports = class BrowserRunner extends Runner {
+    constructor(browserId, config, browserPool) {
+        super();
+
         this._browserId = browserId;
         this._config = config;
         this._browserAgent = BrowserAgent.create(browserId, browserPool);
         this._suiteRunners = [];
-    },
+    }
 
-    run: function(suiteCollection, stateProcessor) {
+    static create(browserId, config, browserPool) {
+        return new BrowserRunner(browserId, config, browserPool);
+    }
+
+    run(suiteCollection, stateProcessor) {
         log('start browser %s', this._browserId);
         this.emit(RunnerEvents.START_BROWSER, {browserId: this._browserId});
         return this._runSuites(suiteCollection, stateProcessor)
@@ -30,54 +35,44 @@ var BrowserRunner = inherit(Runner, {
                 log('stop browser %s', this._browserId);
                 this.emit(RunnerEvents.STOP_BROWSER, {browserId: this._browserId});
             });
-    },
+    }
 
-    cancel: function() {
+    cancel() {
         this._runSuite = this._doNothing;
-        this._suiteRunners.forEach(function(runner) {
-            runner.cancel();
-        });
-    },
+        this._suiteRunners.forEach((runner) => runner.cancel());
+    }
 
-    _doNothing: function() {
-        return q.resolve();
-    },
+    _doNothing() {
+        return q();
+    }
 
-    _runSuites: function(suiteCollection, stateProcessor) {
-        var _this = this;
-
+    _runSuites(suiteCollection, stateProcessor) {
         const suites = suiteCollection.clone().allSuites();
 
         return _(suites)
-            .filter(function(suite) {
-                return _.includes(suite.browsers, _this._browserId);
-            })
-            .map(function(suite) {
-                return _this._tryToRunSuite(suite, stateProcessor);
-            })
+            .filter((suite) => _.includes(suite.browsers, this._browserId))
+            .map((suite) => this._tryToRunSuite(suite, stateProcessor))
             .thru(promiseUtils.waitForResults)
             .value();
-    },
+    }
 
-    _tryToRunSuite: function(suite, stateProcessor) {
-        var _this = this;
-
-        return _this._runSuite(suite, stateProcessor)
-            .fail(function(e) {
+    _tryToRunSuite(suite, stateProcessor) {
+        return this._runSuite(suite, stateProcessor)
+            .fail((e) => {
                 if (e instanceof CancelledError) {
-                    log('critical error %o in %s', e, _this._browserId);
+                    log('critical error %o in %s', e, this._browserId);
                     return;
                 }
 
-                return _this.emitAndWait(PrivateEvents.CRITICAL_ERROR, _.extend(e, {
+                return this.emitAndWait(PrivateEvents.CRITICAL_ERROR, _.extend(e, {
                     suite: suite,
-                    browserId: _this._browserId
+                    browserId: this._browserId
                 }));
             });
-    },
+    }
 
-    _runSuite: function(suite, stateProcessor) {
-        var runner = SuiteRunner.create(suite, this._browserAgent, this._config);
+    _runSuite(suite, stateProcessor) {
+        const runner = SuiteRunner.create(suite, this._browserAgent, this._config);
 
         this.passthroughEvent(runner, [
             RunnerEvents.BEGIN_SUITE,
@@ -95,10 +90,4 @@ var BrowserRunner = inherit(Runner, {
         this._suiteRunners.push(runner);
         return runner.run(stateProcessor);
     }
-}, {
-    create: function(browserId, config, browserPool) {
-        return new BrowserRunner(browserId, config, browserPool);
-    }
-});
-
-module.exports = BrowserRunner;
+};

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -74,8 +74,7 @@ module.exports = class TestsRunner extends Runner {
         sessionRunner.on(RunnerEvents.ERROR, (error) => this._handleError(error));
         sessionRunner.on(PrivateEvents.CRITICAL_ERROR, (error) => this._handleCriticalError(error));
 
-        const suites = suiteCollection.allSuites();
-        return sessionRunner.run(suites, this._stateProcessor)
+        return sessionRunner.run(suiteCollection, this._stateProcessor)
             .then(() => this._failCollector.retry((tests) => this._runTestSession(tests), suiteCollection));
     }
 

--- a/lib/runner/test-session-runner.js
+++ b/lib/runner/test-session-runner.js
@@ -1,34 +1,37 @@
 'use strict';
 
-var inherit = require('inherit'),
-    _ = require('lodash'),
-    q = require('q'),
-    Runner = require('./runner'),
-    BrowserRunner = require('./browser-runner'),
+const _ = require('lodash');
+const q = require('q');
+const Runner = require('./runner');
+const BrowserRunner = require('./browser-runner');
 
-    promiseUtils = require('q-promise-utils'),
-    RunnerEvents = require('../constants/runner-events'),
-    PrivateEvents = require('./private-events'),
-    pool = require('../browser-pool'),
-    SuiteMonitor = require('../suite-monitor');
+const promiseUtils = require('q-promise-utils');
+const RunnerEvents = require('../constants/runner-events');
+const PrivateEvents = require('./private-events');
+const pool = require('../browser-pool');
+const SuiteMonitor = require('../suite-monitor');
 
-var TestSessionRunner = inherit(Runner, {
-    __constructor: function(config, testBrowsers) {
+module.exports = class TestSessionRunner extends Runner {
+    constructor(config, testBrowsers) {
+        super();
+
         this.browserPool = pool.create(config);
 
         this.monitor = new SuiteMonitor(this);
         this.passthroughEvent(this.monitor, RunnerEvents.END_SUITE);
 
-        var allBrowsers = config.getBrowserIds(),
-            browsersToRun = testBrowsers ? _.intersection(testBrowsers, allBrowsers) : allBrowsers;
+        const allBrowsers = config.getBrowserIds();
+        const browsersToRun = testBrowsers ? _.intersection(testBrowsers, allBrowsers) : allBrowsers;
 
-        this._browserRunners = browsersToRun.map(function(browserId) {
-            return this._initBrowserRunner(browserId, config);
-        }, this);
-    },
+        this._browserRunners = browsersToRun.map((browserId) => this._initBrowserRunner(browserId, config));
+    }
 
-    _initBrowserRunner: function(browserId, config) {
-        var runner = BrowserRunner.create(browserId, config, this.browserPool);
+    static create(config, testBrowsers) {
+        return new TestSessionRunner(config, testBrowsers);
+    }
+
+    _initBrowserRunner(browserId, config) {
+        const runner = BrowserRunner.create(browserId, config, this.browserPool);
         this.passthroughEvent(runner, [
             RunnerEvents.START_BROWSER,
             RunnerEvents.STOP_BROWSER,
@@ -45,47 +48,31 @@ var TestSessionRunner = inherit(Runner, {
         ]);
 
         this.passthroughEvent(runner, RunnerEvents.BEGIN_SUITE);
-        runner.on(RunnerEvents.END_SUITE, function(data) {
-            this.monitor.suiteFinished(data.suite, data.browserId);
-        }.bind(this));
+        runner.on(RunnerEvents.END_SUITE, (data) => this.monitor.suiteFinished(data.suite, data.browserId));
 
         return runner;
-    },
+    }
 
-    run: function(suiteCollection, stateProcessor) {
-        var _this = this;
-
+    run(suiteCollection, stateProcessor) {
         this.emit(RunnerEvents.BEGIN_SESSION);
 
         return _(this._browserRunners)
-            .map(function(runner) {
-                return this._runBrowserRunner(runner, suiteCollection, stateProcessor);
-            }.bind(this))
+            .map((runner) => this._runBrowserRunner(runner, suiteCollection, stateProcessor))
             .thru(promiseUtils.waitForResults)
             .value()
-            .fin(function() {
-                _this.emit(RunnerEvents.END_SESSION);
-            });
-    },
+            .fin(() => this.emit(RunnerEvents.END_SESSION));
+    }
 
-    _runBrowserRunner: function(runner, suiteCollection, stateProcessor) {
+    _runBrowserRunner(runner, suiteCollection, stateProcessor) {
         return runner.run(suiteCollection, stateProcessor)
-            .fail(function(e) {
+            .fail((e) => {
                 this._cancel();
                 return q.reject(e);
-            }.bind(this));
-    },
+            });
+    }
 
-    _cancel: function() {
-        this._browserRunners.forEach(function(runner) {
-            runner.cancel();
-        });
+    _cancel() {
+        this._browserRunners.forEach((runner) => runner.cancel());
         this.browserPool.cancel();
     }
-}, {
-    create: function(config, testBrowsers) {
-        return new TestSessionRunner(config, testBrowsers);
-    }
-});
-
-module.exports = TestSessionRunner;
+};

--- a/lib/runner/test-session-runner.js
+++ b/lib/runner/test-session-runner.js
@@ -52,14 +52,14 @@ var TestSessionRunner = inherit(Runner, {
         return runner;
     },
 
-    run: function(suites, stateProcessor) {
+    run: function(suiteCollection, stateProcessor) {
         var _this = this;
 
         this.emit(RunnerEvents.BEGIN_SESSION);
 
         return _(this._browserRunners)
             .map(function(runner) {
-                return this._runBrowserRunner(runner, suites, stateProcessor);
+                return this._runBrowserRunner(runner, suiteCollection, stateProcessor);
             }.bind(this))
             .thru(promiseUtils.waitForResults)
             .value()
@@ -68,8 +68,8 @@ var TestSessionRunner = inherit(Runner, {
             });
     },
 
-    _runBrowserRunner: function(runner, suites, stateProcessor) {
-        return runner.run(suites, stateProcessor)
+    _runBrowserRunner: function(runner, suiteCollection, stateProcessor) {
+        return runner.run(suiteCollection, stateProcessor)
             .fail(function(e) {
                 this._cancel();
                 return q.reject(e);

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,52 +1,51 @@
 'use strict';
 
-var inherit = require('inherit'),
-    _ = require('lodash'),
-    suiteUtil = require('./suite-util');
+const _ = require('lodash');
+const suiteUtil = require('./suite-util');
 
-var State = module.exports = inherit({
-    __constructor: function(suite, name) {
+module.exports = class State {
+    constructor(suite, name) {
         this.suite = suite;
         this.name = name;
         this._ownTolerance = null;
         this.actions = [];
         this.browsers = _.clone(suite.browsers);
-    },
+    }
 
-    clone: function() {
+    clone() {
         const clonedState = new State(this.suite, this.name);
         ['_ownTolerance', 'actions'].forEach((prop) => {
             clonedState[prop] = _.clone(this[prop]);
         });
 
         return clonedState;
-    },
+    }
 
-    shouldSkip: function(browserId) {
+    shouldSkip(browserId) {
         return suiteUtil.shouldSkip(this.suite, browserId);
-    },
+    }
 
     get fullName() {
-        return this.suite.fullName + ' ' + this.name;
-    },
+        return `${this.suite.fullName} ${this.name}`;
+    }
 
     get skipped() {
         return this.suite.skipped;
-    },
+    }
 
     get captureSelectors() {
         return this.suite.captureSelectors;
-    },
+    }
 
     get ignoreSelectors() {
         return this.suite.ignoreSelectors;
-    },
+    }
 
     get tolerance() {
         return this._ownTolerance === null ? this.suite.tolerance : this._ownTolerance;
-    },
+    }
 
     set tolerance(value) {
         this._ownTolerance = value;
     }
-});
+};

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,15 +1,25 @@
 'use strict';
 
 var inherit = require('inherit'),
+    _ = require('lodash'),
     suiteUtil = require('./suite-util');
 
-module.exports = inherit({
+var State = module.exports = inherit({
     __constructor: function(suite, name) {
         this.suite = suite;
         this.name = name;
         this._ownTolerance = null;
         this.actions = [];
-        this.browsers = suite.browsers;
+        this.browsers = _.clone(suite.browsers);
+    },
+
+    clone: function() {
+        const clonedState = new State(this.suite, this.name);
+        ['_ownTolerance', 'actions'].forEach((prop) => {
+            clonedState[prop] = _.clone(this[prop]);
+        });
+
+        return clonedState;
     },
 
     shouldSkip: function(browserId) {

--- a/lib/suite-collection.js
+++ b/lib/suite-collection.js
@@ -6,13 +6,18 @@ const SuiteBuilder = require('./tests-api/suite-builder');
 
 module.exports = class SuiteCollection {
     constructor(suites) {
-        this._suites = suites || [];
+        this._suites = _.clone(suites) || [];
         this._originalBrowsers = {};
     }
 
     add(suite) {
         this._suites.push(suite);
         return this;
+    }
+
+    clone() {
+        const clonedSuites = this._suites.map((suite) => suite.clone());
+        return new SuiteCollection(clonedSuites);
     }
 
     topLevelSuites() {

--- a/lib/suite-collection.js
+++ b/lib/suite-collection.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const format = require('util').format;
 const SuiteBuilder = require('./tests-api/suite-builder');
 
 module.exports = class SuiteCollection {
@@ -100,7 +99,7 @@ module.exports = class SuiteCollection {
         const state = _.find(suite.states, {name});
 
         if (!state) {
-            throw new Error(format('No such state `%s` in suite `%s`', name, suite.fullName));
+            throw new Error(`No such state ${name} in suite ${suite.fullName}`);
         }
 
         return state;

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var inherit = require('inherit'),
-    _ = require('lodash');
+const _ = require('lodash');
 
 function definePrivate(suite) {
     Object.defineProperty(suite, '_states', {
@@ -13,8 +12,8 @@ function definePrivate(suite) {
     });
 }
 
-var Suite = inherit({
-    __constructor: function(name) {
+module.exports = class Suite {
+    constructor(name) {
         this.name = name;
         this.url = null;
         this.skipped = false;
@@ -26,14 +25,33 @@ var Suite = inherit({
         this.browsers = [];
         this.context = {};
         definePrivate(this);
-    },
+    }
 
-    addState: function(state) {
+    static create(name, parent) {
+        if (!parent) {
+            return new Suite(name);
+        }
+
+        if (_.isEmpty(name)) {
+            throw new Error('Empty suite name');
+        }
+
+        const suite = Object.create(parent);
+        definePrivate(suite);
+        suite.name = name;
+        suite.path = parent.path ? parent.path.concat(name) : [name];
+        suite.context = _.clone(parent.context);
+        suite.parent = parent;
+
+        return suite;
+    }
+
+    addState(state) {
         state.suite = this;
         this._states.push(state);
-    },
+    }
 
-    skip: function(browserSkipMatcher) {
+    skip(browserSkipMatcher) {
         if (this.skipped === true) {
             return;
         }
@@ -45,9 +63,9 @@ var Suite = inherit({
                 ? this.skipped.concat(browserSkipMatcher)
                 : [browserSkipMatcher];
         }
-    },
+    }
 
-    clone: function() {
+    clone() {
         const clonedSuite = Suite.create(this.name, this.parent);
 
         _.forOwn(this, (value, key) => {
@@ -60,71 +78,50 @@ var Suite = inherit({
         this.states.forEach((state) => clonedSuite.addState(state.clone()));
 
         return clonedSuite;
-    },
+    }
 
-    hasChildNamed: function(name) {
+    hasChildNamed(name) {
         return _.some(this._children, {name: name});
-    },
+    }
 
-    hasStateNamed: function(name) {
+    hasStateNamed(name) {
         return _.some(this._states, {name: name});
-    },
+    }
 
     get states() {
         return this._states;
-    },
+    }
 
     get children() {
         return this._children;
-    },
+    }
 
-    addChild: function(child) {
+    addChild(child) {
         Object.setPrototypeOf(child, this);
         child.parent = this;
         this._children.push(child);
-    },
+    }
 
-    removeChild: function(suite) {
-        var index = _.indexOf(this._children, suite);
+    removeChild(suite) {
+        const index = _.indexOf(this._children, suite);
 
         if (index !== -1) {
             suite.parent = null;
             this._children.splice(index, 1);
         }
-    },
+    }
 
     get hasStates() {
         return this._states.length > 0;
-    },
+    }
 
     get isRoot() {
         return !this.parent;
-    },
+    }
 
     get fullName() {
         return this.isRoot
             ? this.name
             : _.compact([this.parent.fullName, this.name]).join(' ');
     }
-}, {
-    create: function createSuite(name, parent) {
-        if (!parent) {
-            return new Suite(name);
-        }
-
-        if (_.isEmpty(name)) {
-            throw new Error('Empty suite name');
-        }
-
-        var suite = Object.create(parent);
-        definePrivate(suite);
-        suite.name = name;
-        suite.path = parent.path ? parent.path.concat(name) : [name];
-        suite.context = _.clone(parent.context);
-        suite.parent = parent;
-
-        return suite;
-    }
-});
-
-exports.create = Suite.create;
+};

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -29,6 +29,7 @@ var Suite = inherit({
     },
 
     addState: function(state) {
+        state.suite = this;
         this._states.push(state);
     },
 
@@ -44,6 +45,21 @@ var Suite = inherit({
                 ? this.skipped.concat(browserSkipMatcher)
                 : [browserSkipMatcher];
         }
+    },
+
+    clone: function() {
+        const clonedSuite = Suite.create(this.name, this.parent);
+
+        _.forOwn(this, (value, key) => {
+            if (key !== 'parent') {
+                clonedSuite[key] = _.clone(this[key]);
+            }
+        });
+
+        this.children.forEach((child) => clonedSuite.addChild(child.clone()));
+        this.states.forEach((state) => clonedSuite.addState(state.clone()));
+
+        return clonedSuite;
     },
 
     hasChildNamed: function(name) {
@@ -62,9 +78,10 @@ var Suite = inherit({
         return this._children;
     },
 
-    addChild: function(suite) {
-        suite.parent = this;
-        this._children.push(suite);
+    addChild: function(child) {
+        Object.setPrototypeOf(child, this);
+        child.parent = this;
+        this._children.push(child);
     },
 
     removeChild: function(suite) {
@@ -89,22 +106,25 @@ var Suite = inherit({
             ? this.name
             : _.compact([this.parent.fullName, this.name]).join(' ');
     }
+}, {
+    create: function createSuite(name, parent) {
+        if (!parent) {
+            return new Suite(name);
+        }
+
+        if (_.isEmpty(name)) {
+            throw new Error('Empty suite name');
+        }
+
+        var suite = Object.create(parent);
+        definePrivate(suite);
+        suite.name = name;
+        suite.path = parent.path ? parent.path.concat(name) : [name];
+        suite.context = _.clone(parent.context);
+        suite.parent = parent;
+
+        return suite;
+    }
 });
 
-exports.create = function createSuite(name, parent) {
-    if (!parent) {
-        return new Suite(name);
-    }
-
-    if (_.isEmpty(name)) {
-        throw new Error('Empty suite name');
-    }
-
-    var suite = Object.create(parent);
-    definePrivate(suite);
-    suite.name = name;
-    suite.path = parent.path ? parent.path.concat(name) : [name];
-    suite.context = _.clone(parent.context);
-    parent.addChild(suite);
-    return suite;
-};
+exports.create = Suite.create;

--- a/lib/tests-api/index.js
+++ b/lib/tests-api/index.js
@@ -1,14 +1,14 @@
 'use strict';
-var Suite = require('../suite'),
-    SuiteBuilder = require('./suite-builder'),
 
-    keysCodes = require('./keys-codes');
+const Suite = require('../suite');
+const SuiteBuilder = require('./suite-builder');
+const keysCodes = require('./keys-codes');
 
-module.exports = function(suite, browsers) {
-    var suiteId = 1,
-        testsAPI = keysCodes;
+module.exports = (suite, browsers) => {
+    let suiteId = 1;
+    const testsAPI = keysCodes;
 
-    testsAPI.suite = function(name, callback) {
+    testsAPI.suite = (name, callback) => {
         if (typeof name !== 'string') {
             throw new TypeError('First argument of the gemini.suite must be a string');
         }
@@ -18,10 +18,10 @@ module.exports = function(suite, browsers) {
         }
 
         if (suite.hasChildNamed(name)) {
-            throw new Error('Suite ' + name + ' already exists at this level. Choose different name');
+            throw new Error(`Suite ${name} already exists at this level. Choose different name`);
         }
 
-        var parent = suite;
+        const parent = suite;
         suite = Suite.create(name, parent);
         parent.addChild(suite);
         suite.id = suiteId++;

--- a/lib/tests-api/index.js
+++ b/lib/tests-api/index.js
@@ -21,7 +21,9 @@ module.exports = function(suite, browsers) {
             throw new Error('Suite ' + name + ' already exists at this level. Choose different name');
         }
 
-        suite = Suite.create(name, suite);
+        var parent = suite;
+        suite = Suite.create(name, parent);
+        parent.addChild(suite);
         suite.id = suiteId++;
         if (browsers && suite.parent.isRoot) {
             suite.browsers = browsers;

--- a/test/unit/gemini.test.js
+++ b/test/unit/gemini.test.js
@@ -9,6 +9,7 @@ const Runner = require('lib/runner');
 const temp = require('lib/temp');
 
 const mkSuiteStub = require('../util').makeSuiteStub;
+const mkStateStub = require('../util').makeStateStub;
 
 describe('gemini', () => {
     const sandbox = sinon.sandbox.create();
@@ -94,6 +95,9 @@ describe('gemini', () => {
             const child = mkSuiteStub({parent: parent});
             const anotherChild = mkSuiteStub({parent: parent});
 
+            parent.addChild(child);
+            parent.addChild(anotherChild);
+
             return readTests_(parent)
                 .then((collection) => {
                     const allSuites = collection.allSuites();
@@ -107,16 +111,19 @@ describe('gemini', () => {
         it('should grep leaf suites by fullname', () => {
             const grandParent = mkSuiteStub();
             const parent = mkSuiteStub({parent: grandParent});
+            grandParent.addChild(parent);
             const matchingChild = mkSuiteStub({
-                states: [1],
+                states: [mkStateStub()],
                 name: 'ok',
                 parent: parent
             });
             const nonMatchingChild = mkSuiteStub({
-                states: [1],
+                states: [mkStateStub()],
                 name: 'fail',
                 parent: parent
             });
+            parent.addChild(matchingChild);
+            parent.addChild(nonMatchingChild);
 
             return readTests_(parent, {grep: /ok/})
                 .then((collection) => {
@@ -135,7 +142,7 @@ describe('gemini', () => {
                 parent: parent
             });
             const nonMatchingBranchLeaf = mkSuiteStub({
-                states: [1],
+                states: [mkStateStub()],
                 name: 'nonMatchingBranchLeaf',
                 parent: nonMatchingBranchRoot
             });
@@ -152,15 +159,18 @@ describe('gemini', () => {
         it('should keep in tree branch that have matching leaf suites', () => {
             const grandParent = mkSuiteStub();
             const parent = mkSuiteStub({parent: grandParent});
+            grandParent.addChild(parent);
             const matchingBranchRoot = mkSuiteStub({
                 name: 'matchingBranchRoot',
                 parent: parent
             });
+            parent.addChild(matchingBranchRoot);
             const matchingBranchLeaf = mkSuiteStub({
-                states: [1],
+                states: [mkStateStub()],
                 name: 'matchingBranchLeaf',
                 parent: matchingBranchRoot
             });
+            matchingBranchRoot.addChild(matchingBranchLeaf);
 
             return readTests_(grandParent, {grep: /matchingBranchLeaf/})
                 .then((collection) => {

--- a/test/unit/runner/browser-runner/index.js
+++ b/test/unit/runner/browser-runner/index.js
@@ -8,6 +8,7 @@ const suiteRunnerFabric = require('lib/runner/suite-runner');
 const CancelledError = require('lib/errors/cancelled-error');
 const BasicPool = require('lib/browser-pool/basic-pool');
 const Config = require('lib/config');
+const SuiteCollection = require('lib/suite-collection');
 
 const makeSuiteStub = require('../../../util').makeSuiteStub;
 
@@ -46,25 +47,34 @@ describe('runner/BrowserRunner', () => {
     });
 
     describe('run', () => {
+        let suiteCollection;
+
+        beforeEach(() => {
+            suiteCollection = {
+                clone: () => suiteCollection,
+                allSuites: () => []
+            };
+        });
+
         it('should emit `startBrowser` event when starting browser', () => {
             const onStartBrowser = sinon.spy().named('onStartBrowser');
             const runner = mkRunner_('browser');
 
             runner.on('startBrowser', onStartBrowser);
 
-            return runner.run([])
+            return runner.run(suiteCollection)
                 .then(() => assert.calledWith(onStartBrowser, {browserId: 'browser'}));
         });
 
         it('should run only suites expected to be run in current browser', () => {
             const someSuite = makeSuiteStub({browsers: ['browser1', 'browser2']});
-            const suites = [
+            const suiteCollection = new SuiteCollection([
                 someSuite,
                 makeSuiteStub({browsers: ['browser2']})
-            ];
+            ]);
             const runner = mkRunner_('browser1');
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => {
                     assert.calledOnce(suiteRunnerFabric.create);
                     assert.calledWith(suiteRunnerFabric.create, someSuite);
@@ -73,43 +83,43 @@ describe('runner/BrowserRunner', () => {
 
         it('should pass to suite runner browser agent associated with current browser', () => {
             const browserAgent = new BrowserAgent('browser');
-            const suites = [makeSuiteStub({browsers: ['browser']})];
+            const suiteCollection = new SuiteCollection([makeSuiteStub({browsers: ['browser']})]);
 
             sandbox.stub(BrowserAgent, 'create');
             BrowserAgent.create.returns(browserAgent);
 
             const runner = mkRunner_('browser');
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => assert.calledWith(suiteRunnerFabric.create, sinon.match.any, browserAgent));
         });
 
         it('should passthrough stateProcessor to suite runner', () => {
-            const suites = [makeSuiteStub({browsers: ['browser']})];
+            const suiteCollection = new SuiteCollection([makeSuiteStub({browsers: ['browser']})]);
             const runner = mkRunner_('browser');
 
-            return runner.run(suites, 'stateProcessor')
+            return runner.run(suiteCollection, 'stateProcessor')
                 .then(() => assert.calledWith(suiteRunner.run, 'stateProcessor'));
         });
 
         it('should not run suites after cancel', () => {
             const runner = mkRunner_('browser');
-            const suites = [{browsers: ['browser']}];
+            const suiteCollection = new SuiteCollection([makeSuiteStub({browsers: ['browser']})]);
 
             runner.cancel();
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => assert.notCalled(suiteRunner.run));
         });
 
         it('should cancel suite runners on cancel', () => {
             const runner = mkRunner_('browser');
-            const suites = [
+            const suiteCollection = new SuiteCollection([
                 makeSuiteStub({browsers: ['browser']}),
                 makeSuiteStub({browsers: ['browser']})
-            ];
+            ]);
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => {
                     runner.cancel();
 
@@ -123,20 +133,20 @@ describe('runner/BrowserRunner', () => {
 
             runner.on('startBrowser', onStopBrowser);
 
-            return runner.run([])
+            return runner.run(suiteCollection)
                 .then(() => assert.calledWith(onStopBrowser, {browserId: 'browser'}));
         });
 
         it('should emit events in correct order', () => {
             const startBrowser = sinon.spy().named('onStartBrowser');
             const stopBrowser = sinon.spy().named('onStopBrowser');
-            const suites = [makeSuiteStub({browsers: ['browser']})];
+            const suiteCollection = new SuiteCollection([makeSuiteStub({browsers: ['browser']})]);
             const runner = mkRunner_('browser');
 
             runner.on('startBrowser', startBrowser);
             runner.on('stopBrowser', stopBrowser);
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => {
                     assert.callOrder(
                         startBrowser,
@@ -150,43 +160,43 @@ describe('runner/BrowserRunner', () => {
     describe('critical error', () => {
         it('should emit `criticalError` event on error', () => {
             const onCriticalError = sinon.spy().named('onCriticalError');
-            const suites = [makeSuiteStub({browsers: ['browser']})];
+            const suiteCollection = new SuiteCollection([makeSuiteStub({browsers: ['browser']})]);
             const runner = mkRunner_('browser');
 
             runner.on('criticalError', onCriticalError);
             suiteRunner.run.onFirstCall().returns(q.reject(new Error('error')));
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => assert.calledOnce(onCriticalError));
         });
 
         it('should not emit `criticalError` if it was manually stopped', () => {
             const onCriticalError = sinon.spy().named('onCriticalError');
-            const suites = [makeSuiteStub()];
+            const suiteCollection = new SuiteCollection([makeSuiteStub()]);
             const runner = mkRunner_();
 
             runner.on('criticalError', onCriticalError);
             suiteRunner.run.onFirstCall().returns(q.reject(new CancelledError()));
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => assert.notCalled(onCriticalError));
         });
 
         it('should pass suite and browser id as critical error event data', () => {
             const onCriticalError = sinon.spy().named('onCriticalError');
-            const suite = makeSuiteStub({browsers: ['browser']});
-            const suites = [suite];
+            const suite = makeSuiteStub({name: 'some suite', browsers: ['browser']});
+            const suiteCollection = new SuiteCollection([suite]);
             const runner = mkRunner_('browser');
 
             runner.on('criticalError', onCriticalError);
             suiteRunner.run.onFirstCall().returns(q.reject(new Error('error')));
 
-            return runner.run(suites)
+            return runner.run(suiteCollection)
                 .then(() => {
                     const err = onCriticalError.firstCall.args[0];
 
-                    assert.equal(suite, err.suite);
-                    assert.equal('browser', err.browserId);
+                    assert.equal(err.suite.name, suite.name);
+                    assert.equal(err.browserId, 'browser');
                 });
         });
     });

--- a/test/unit/runner/index.js
+++ b/test/unit/runner/index.js
@@ -8,7 +8,6 @@ const TestSessionRunner = require('lib/runner/test-session-runner');
 const StateProcessor = require('lib/state-processor/state-processor');
 const Config = require('lib/config');
 const FailCollector = require('lib/fail-collector');
-const util = require('../../util');
 
 describe('runner', () => {
     const sandbox = sinon.sandbox.create();
@@ -105,14 +104,11 @@ describe('runner', () => {
         });
 
         it('should run suites in test session runner', () => {
-            const suites = [util.makeSuiteStub()];
-
-            suiteCollectionStub.allSuites.returns(suites);
             sandbox.stub(testSessionRunner, 'run').returns(q());
 
             return run_(suiteCollectionStub).then(() => {
                 assert.calledOnce(testSessionRunner.run);
-                assert.calledWith(testSessionRunner.run, suites, stateProcessor);
+                assert.calledWith(testSessionRunner.run, suiteCollectionStub, stateProcessor);
             });
         });
 

--- a/test/unit/runner/test-session-runner.js
+++ b/test/unit/runner/test-session-runner.js
@@ -1,33 +1,31 @@
 'use strict';
-var q = require('q'),
-    TestSessionRunner = require('lib/runner/test-session-runner'),
-    BrowserRunner = require('lib/runner/browser-runner'),
-    pool = require('lib/browser-pool'),
-    BasicPool = require('lib/browser-pool/basic-pool'),
-    Config = require('lib/config');
 
-describe('runner/TestSessionRunner', function() {
-    var sandbox = sinon.sandbox.create(),
-        config;
+const q = require('q');
+const TestSessionRunner = require('lib/runner/test-session-runner');
+const BrowserRunner = require('lib/runner/browser-runner');
+const pool = require('lib/browser-pool');
+const BasicPool = require('lib/browser-pool/basic-pool');
+const Config = require('lib/config');
 
-    beforeEach(function() {
+describe('runner/TestSessionRunner', () => {
+    const sandbox = sinon.sandbox.create();
+    let config;
+
+    beforeEach(() => {
         sandbox.stub(pool, 'create');
         config = sinon.createStubInstance(Config);
     });
 
-    afterEach(function() {
-        sandbox.restore();
-    });
+    afterEach(() => sandbox.restore());
 
-    describe('create', function() {
-        beforeEach(function() {
+    describe('create', () => {
+        beforeEach(() => {
             sandbox.stub(BrowserRunner, 'create');
             BrowserRunner.create.returns(sinon.createStubInstance(BrowserRunner));
         });
 
-        it('should create runner for each browser in config if testBrowsers are not set', function() {
-            config.getBrowserIds
-                .returns(['browser1', 'browser2']);
+        it('should create runner for each browser in config if testBrowsers are not set', () => {
+            config.getBrowserIds.returns(['browser1', 'browser2']);
 
             TestSessionRunner.create(config);
 
@@ -36,9 +34,8 @@ describe('runner/TestSessionRunner', function() {
             assert.calledWith(BrowserRunner.create, 'browser2');
         });
 
-        it('should launch only browsers specified in testBrowsers', function() {
-            config.getBrowserIds
-                .returns(['browser1', 'browser2']);
+        it('should launch only browsers specified in testBrowsers', () => {
+            config.getBrowserIds.returns(['browser1', 'browser2']);
 
             TestSessionRunner.create(config, ['browser1']);
 
@@ -47,34 +44,32 @@ describe('runner/TestSessionRunner', function() {
         });
     });
 
-    describe('run', function() {
-        beforeEach(function() {
-            sandbox.stub(BrowserRunner.prototype);
-            BrowserRunner.prototype.run.returns(q.resolve());
+    describe('run', () => {
+        beforeEach(() => {
+            sandbox.stub(BrowserRunner.prototype, 'run');
+            BrowserRunner.prototype.run.returns(q());
         });
 
         function run_(suites, stateProcessor) {
             return TestSessionRunner.create(config).run(suites || [], stateProcessor);
         }
 
-        it('should emit `beginSession` event on start runner', function() {
-            config.getBrowserIds
-                .returns(['browser1']);
+        it('should emit `beginSession` event on start runner', () => {
+            config.getBrowserIds.returns(['browser1']);
 
-            var onBeginSession = sandbox.spy().named('onBeginSession'),
-                runner = TestSessionRunner.create(config);
+            const onBeginSession = sandbox.spy().named('onBeginSession');
+            const runner = TestSessionRunner.create(config);
 
             runner.on('beginSession', onBeginSession);
 
             runner.run()
-                .then(function() {
+                .then(() => {
                     assert.called(onBeginSession);
                 });
         });
 
-        it('shoud run all created runners', function() {
-            config.getBrowserIds
-                .returns(['browser1', 'browser2']);
+        it('shoud run all created runners', () => {
+            config.getBrowserIds.returns(['browser1', 'browser2']);
 
             run_();
 
@@ -85,18 +80,17 @@ describe('runner/TestSessionRunner', function() {
             );
         });
 
-        it('should run all suites in browser runner', function() {
-            config.getBrowserIds
-                .returns(['browser1']);
-            var suites = [];
+        it('should run all suites in browser runner', () => {
+            config.getBrowserIds.returns(['browser1']);
+            const suites = [];
 
             run_(suites);
 
             assert.calledWith(BrowserRunner.prototype.run, suites);
         });
 
-        it('should pass through stateProcessor to browserRunner', function() {
-            var stateProcessor = 'stateProcessor';
+        it('should pass through stateProcessor to browserRunner', () => {
+            const stateProcessor = 'stateProcessor';
 
             config.getBrowserIds.returns(['browser']);
             run_([], stateProcessor);
@@ -104,66 +98,63 @@ describe('runner/TestSessionRunner', function() {
             assert.calledWith(BrowserRunner.prototype.run, sinon.match.any, stateProcessor);
         });
 
-        it('should emit `endSession` event after test session finished', function() {
-            config.getBrowserIds
-                .returns(['browser1']);
+        it('should emit `endSession` event after test session finished', () => {
+            config.getBrowserIds.returns(['browser1']);
 
-            var onEndSession = sandbox.spy().named('onEndSession'),
-                runner = TestSessionRunner.create(config);
+            const onEndSession = sandbox.spy().named('onEndSession');
+            const runner = TestSessionRunner.create(config);
 
             runner.on('endSession', onEndSession);
 
             return runner.run()
-                .then(function() {
+                .then(() => {
                     assert.called(onEndSession);
                 });
         });
 
-        it('should emit `beginSession` and `endSession` events in correct order', function() {
-            config.getBrowserIds
-                .returns(['browser1']);
+        it('should emit `beginSession` and `endSession` events in correct order', () => {
+            config.getBrowserIds.returns(['browser1']);
 
-            var onBeginSession = sandbox.spy().named('onBeginSession'),
-                onEndSession = sandbox.spy().named('onEndSession'),
-                runner = TestSessionRunner.create(config);
+            const onBeginSession = sandbox.spy().named('onBeginSession');
+            const onEndSession = sandbox.spy().named('onEndSession');
+            const runner = TestSessionRunner.create(config);
 
             runner.on('beginSession', onBeginSession);
             runner.on('endSession', onEndSession);
 
             return runner.run()
-                .then(function() {
+                .then(() => {
                     assert.callOrder(onBeginSession, onEndSession);
                 });
         });
 
-        describe('on error', function() {
-            beforeEach(function() {
-                config.getBrowserIds
-                    .returns(['browser1', 'browser2']);
+        describe('on error', () => {
+            beforeEach(() => {
+                config.getBrowserIds.returns(['browser1', 'browser2']);
 
-                BrowserRunner.prototype.run
-                    .onFirstCall().returns(q.reject());
+                BrowserRunner.prototype.run.onFirstCall().returns(q.reject());
 
                 pool.create.returns(sinon.createStubInstance(BasicPool));
             });
 
-            it('should be rejected', function() {
+            it('should be rejected', () => {
                 return assert.isRejected(run_());
             });
 
-            it('should cancel all runners', function() {
+            it('should cancel all runners', () => {
+                sandbox.stub(BrowserRunner.prototype, 'cancel');
                 return run_()
-                    .fail(function() {
+                    .fail(() => {
                         assert.calledTwice(BrowserRunner.prototype.cancel);
                     });
             });
 
-            it('should cancel browser pool', function() {
-                var browserPool = sinon.createStubInstance(BasicPool);
+            it('should cancel browser pool', () => {
+                const browserPool = sinon.createStubInstance(BasicPool);
                 pool.create.returns(browserPool);
 
                 return run_()
-                    .fail(function() {
+                    .fail(() => {
                         assert.calledOnce(browserPool.cancel);
                     });
             });

--- a/test/unit/state.js
+++ b/test/unit/state.js
@@ -54,4 +54,32 @@ describe('state methods', () => {
             assert.equal(state[method], suite[method]);
         });
     });
+
+    describe('clone method', () => {
+        it('should return cloned state', () => {
+            const state = new State({});
+            const clonedState = state.clone();
+
+            assert.notEqual(state, clonedState);
+        });
+
+        it('should clone actions from the origin state', () => {
+            const state = new State({});
+            state.actions.push('actions');
+
+            const clonedState = state.clone();
+            state.actions.push('anotherAction');
+
+            assert.deepEqual(clonedState.actions, ['actions']);
+        });
+
+        it('should clone tolerance from the origin state', () => {
+            const state = new State({});
+            state.tolerance = 100;
+
+            const clonedState = state.clone();
+
+            assert.equal(clonedState.tolerance, 100);
+        });
+    });
 });

--- a/test/unit/suite-collection.js
+++ b/test/unit/suite-collection.js
@@ -53,6 +53,51 @@ describe('suite-collection', () => {
         });
     });
 
+    describe('clone method', () => {
+        it('should leave top level parent for each tl suite', () => {
+            const tree = mkTree({
+                parent: {
+                    child: []
+                }
+            });
+
+            const collection = new SuiteCollection([tree.child]);
+            const clonedCollection = collection.clone();
+            const clonedChild = clonedCollection.topLevelSuites()[0];
+
+            assert.equal(clonedChild.parent, tree.child.parent);
+        });
+
+        it('should not add new children to top level parent', () => {
+            const tree = mkTree({
+                parent: {
+                    child: []
+                }
+            });
+
+            const collection = new SuiteCollection([tree.child]);
+            const clonedCollection = collection.clone();
+
+            assert.lengthOf(clonedCollection.topLevelSuites()[0].parent.children, 1);
+        });
+
+        it('should return new suite collection', () => {
+            const collection = new SuiteCollection();
+            const clonedCollection = collection.clone();
+
+            assert.notEqual(clonedCollection, collection);
+        });
+
+        it('should clone all suites from the collection', () => {
+            const tree = mkTree({suite: []});
+            const collection = new SuiteCollection([tree.suite]);
+            sandbox.stub(tree.suite, 'clone');
+            collection.clone();
+
+            assert.calledOnce(collection.topLevelSuites()[0].clone);
+        });
+    });
+
     describe('allSuites', () => {
         it('should return empty list on empty collection', () => {
             const collection = new SuiteCollection();

--- a/test/unit/suite-monitor.test.js
+++ b/test/unit/suite-monitor.test.js
@@ -8,6 +8,7 @@ describe('suite-monitor', function() {
 
         this.root = createSuite('root');
         this.suite = createSuite('suite', this.root);
+        this.root.addChild(this.suite);
 
         this.monitor = new SuiteMonitor();
     });
@@ -34,6 +35,7 @@ describe('suite-monitor', function() {
         it('should emit `endSuite` event when passed suite has complete nested suits', function() {
             var spy = this.sinon.spy().named('onEndSuite');
             this.child = createSuite('child', this.suite);
+            this.suite.addChild(this.child);
             this.monitor.on('endSuite', spy);
             this.monitor.suiteFinished(this.root, 'browser');
             this.monitor.suiteFinished(this.suite, 'browser');

--- a/test/unit/suite-monitor.test.js
+++ b/test/unit/suite-monitor.test.js
@@ -1,49 +1,57 @@
 'use strict';
-var createSuite = require('lib/suite').create,
-    SuiteMonitor = require('lib/suite-monitor');
 
-describe('suite-monitor', function() {
-    beforeEach(function() {
-        this.sinon = sinon.sandbox.create();
+const createSuite = require('lib/suite').create;
+const SuiteMonitor = require('lib/suite-monitor');
 
-        this.root = createSuite('root');
-        this.suite = createSuite('suite', this.root);
-        this.root.addChild(this.suite);
+describe('suite-monitor', () => {
+    const sandbox = sinon.sandbox.create();
+    let monitor;
+    let root;
+    let suite;
 
-        this.monitor = new SuiteMonitor();
+    beforeEach(() => {
+        root = createSuite('root');
+        suite = createSuite('suite', root);
+        root.addChild(suite);
+
+        monitor = new SuiteMonitor();
     });
 
-    afterEach(function() {
-        this.sinon.restore();
-    });
+    afterEach(() => sandbox.restore());
 
-    describe('suiteFinished', function() {
-        it('should emit `endSuite` event when passed suite does not have nested suits', function() {
-            var spy = this.sinon.spy().named('onEndSuite');
-            this.monitor.on('endSuite', spy);
-            this.monitor.suiteFinished(this.suite, 'browser');
+    describe('suiteFinished', () => {
+        it('should emit `endSuite` event when passed suite does not have nested suits', () => {
+            const spy = sandbox.spy().named('onEndSuite');
+            monitor.on('endSuite', spy);
+
+            monitor.suiteFinished(suite, 'browser');
+
             assert.calledOnce(spy);
         });
 
-        it('should not emit `endSuite` event when passed suite has incomplete nested suits', function() {
-            var spy = this.sinon.spy().named('onEndSuite');
-            this.monitor.on('endSuite', spy);
-            this.monitor.suiteFinished(this.root, 'browser');
+        it('should not emit `endSuite` event when passed suite has incomplete nested suits', () => {
+            const spy = sandbox.spy().named('onEndSuite');
+            monitor.on('endSuite', spy);
+
+            monitor.suiteFinished(root, 'browser');
+
             assert.neverCalledWith(spy);
         });
 
-        it('should emit `endSuite` event when passed suite has complete nested suits', function() {
-            var spy = this.sinon.spy().named('onEndSuite');
-            this.child = createSuite('child', this.suite);
-            this.suite.addChild(this.child);
-            this.monitor.on('endSuite', spy);
-            this.monitor.suiteFinished(this.root, 'browser');
-            this.monitor.suiteFinished(this.suite, 'browser');
-            this.monitor.suiteFinished(this.child, 'browser');
+        it('should emit `endSuite` event when passed suite has complete nested suits', () => {
+            const spy = sandbox.spy().named('onEndSuite');
+            const child = createSuite('child', suite);
+            suite.addChild(child);
+            monitor.on('endSuite', spy);
+
+            monitor.suiteFinished(root, 'browser');
+            monitor.suiteFinished(suite, 'browser');
+            monitor.suiteFinished(child, 'browser');
+
             assert.callOrder(
-                spy.withArgs(sinon.match({suite: this.child, browserId: 'browser'})),
-                spy.withArgs(sinon.match({suite: this.suite, browserId: 'browser'})),
-                spy.withArgs(sinon.match({suite: this.root, browserId: 'browser'}))
+                spy.withArgs(sinon.match({suite: child, browserId: 'browser'})),
+                spy.withArgs(sinon.match({suite: suite, browserId: 'browser'})),
+                spy.withArgs(sinon.match({suite: root, browserId: 'browser'}))
             );
         });
     });

--- a/test/unit/suite.test.js
+++ b/test/unit/suite.test.js
@@ -4,25 +4,25 @@ const createSuite = require('lib/suite').create;
 const State = require('lib/state');
 const mkTree = require('../util').makeSuiteTree;
 
-describe('suite', function() {
-    describe('create', function() {
-        it('should create named suite', function() {
-            var suite = createSuite('some name');
+describe('suite', () => {
+    describe('create', () => {
+        it('should create named suite', () => {
+            const suite = createSuite('some name');
             assert.equal(suite.name, 'some name');
         });
 
-        it('should inherit properties from parent, if any', function() {
-            var parent = createSuite('parent'),
-                child = createSuite('child', parent);
+        it('should inherit properties from parent, if any', () => {
+            const parent = createSuite('parent');
+            const child = createSuite('child', parent);
 
             parent.url = 'http://example.com';
 
             assert.equal(child.url, parent.url);
         });
 
-        it('should allow to overwrite parent properties', function() {
-            var parent = createSuite('parent'),
-                child = createSuite('child', parent);
+        it('should allow to overwrite parent properties', () => {
+            const parent = createSuite('parent');
+            const child = createSuite('child', parent);
 
             parent.url = 'http://example.com';
             child.url = 'http://example2.com';
@@ -30,27 +30,27 @@ describe('suite', function() {
             assert.notEqual(child.url, parent.url);
         });
 
-        it('should set `parent` property of a parent suite', function() {
-            var parent = createSuite('parent'),
-                child = createSuite('child', parent);
+        it('should set `parent` property of a parent suite', () => {
+            const parent = createSuite('parent');
+            const child = createSuite('child', parent);
 
             assert.equal(child.parent, parent);
         });
 
-        it('child suite should have same data in context as parent', function() {
-            var parent = createSuite('parent');
+        it('child suite should have same data in context as parent', () => {
+            const parent = createSuite('parent');
             parent.context.some = 'data';
 
-            var child = createSuite('child', parent);
+            const child = createSuite('child', parent);
 
             assert.deepEqual(child.context, {some: 'data'});
         });
 
-        it('modifications of child context should not affect parent context', function() {
-            var parent = createSuite('parent');
+        it('modifications of child context should not affect parent context', () => {
+            const parent = createSuite('parent');
             parent.context.some = 'data';
 
-            var child = createSuite('child', parent);
+            const child = createSuite('child', parent);
             child.context.some = 'other-data';
             child.context.other = 'data';
 
@@ -64,26 +64,24 @@ describe('suite', function() {
         });
     });
 
-    describe('states', function() {
-        beforeEach(function() {
-            this.suite = createSuite('suite');
+    describe('states', () => {
+        let suite;
+
+        beforeEach(() => {
+            suite = createSuite('suite');
         });
 
-        it('should be empty by default', function() {
-            assert.lengthOf(this.suite.states, 0);
+        it('should be empty by default', () => {
+            assert.lengthOf(suite.states, 0);
         });
 
-        it('should not be writable', function() {
-            var suite = this.suite;
-
-            assert.throws(function() {
-                suite.states = [];
-            });
+        it('should not be writable', () => {
+            assert.throws(() => suite.states = []);
         });
 
-        it('should not be inherited', function() {
-            var child = createSuite('child', this.suite);
-            this.suite.addState({});
+        it('should not be inherited', () => {
+            const child = createSuite('child', suite);
+            suite.addState({});
             assert.lengthOf(child.states, 0);
         });
     });
@@ -96,14 +94,14 @@ describe('suite', function() {
             assert.equal(suite.children[0], child);
         });
 
-        it('should set himself as a parent for child suite', function() {
+        it('should set himself as a parent for child suite', () => {
             const suite = createSuite('suite');
             const anotherSuite = createSuite('another-suite');
             suite.addChild(anotherSuite);
             assert.equal(anotherSuite.parent, suite);
         });
 
-        it('child suite should inherit properties from the parent', function() {
+        it('child suite should inherit properties from the parent', () => {
             const suite = createSuite('suite');
             const anotherSuite = createSuite('another-suite');
             suite.addChild(anotherSuite);
@@ -111,158 +109,173 @@ describe('suite', function() {
         });
     });
 
-    describe('addState', function() {
-        beforeEach(function() {
-            this.suite = createSuite('suite');
+    describe('addState', () => {
+        let suite;
+
+        beforeEach(() => {
+            suite = createSuite('suite');
         });
 
-        it('should modify states property', function() {
-            var state = {name: 'some state'};
-            this.suite.addState(state);
-            assert.equal(this.suite.states[0], state);
+        it('should modify states property', () => {
+            const state = {name: 'some state'};
+            suite.addState(state);
+            assert.equal(suite.states[0], state);
         });
 
-        it('should redefine parent suite for state', function() {
-            var state = {name: 'some state'};
-            this.suite.addState(state);
-            assert.equal(state.suite, this.suite);
-        });
-    });
-
-    describe('hasStates', function() {
-        beforeEach(function() {
-            this.suite = createSuite('suite');
-        });
-
-        it('should be false if there is no states', function() {
-            assert.isFalse(this.suite.hasStates);
-        });
-
-        it('should be true if there are states', function() {
-            this.suite.addState({name: 'state'});
-
-            assert.isTrue(this.suite.hasStates);
+        it('should redefine parent suite for state', () => {
+            const state = {name: 'some state'};
+            suite.addState(state);
+            assert.equal(state.suite, suite);
         });
     });
 
-    describe('isRoot', function() {
-        it('should be true for root suites', function() {
-            var suite = createSuite('suite');
+    describe('hasStates', () => {
+        let suite;
+
+        beforeEach(() => {
+            suite = createSuite('suite');
+        });
+
+        it('should be false if there is no states', () => {
+            assert.isFalse(suite.hasStates);
+        });
+
+        it('should be true if there are states', () => {
+            suite.addState({name: 'state'});
+
+            assert.isTrue(suite.hasStates);
+        });
+    });
+
+    describe('isRoot', () => {
+        it('should be true for root suites', () => {
+            const suite = createSuite('suite');
             assert.isTrue(suite.isRoot);
         });
 
-        it('should be false for child suites', function() {
-            var parent = createSuite('parent'),
-                child = createSuite('child', parent);
+        it('should be false for child suites', () => {
+            const parent = createSuite('parent');
+            const child = createSuite('child', parent);
 
             assert.isFalse(child.isRoot);
         });
     });
 
-    describe('skipped', function() {
-        beforeEach(function() {
-            this.suite = createSuite('suite');
-            this.matcher = {a: 1};
-            this.matcher2 = {b: 2};
+    describe('skipped', () => {
+        let suite;
+        let matcher;
+        let matcher2;
+
+        beforeEach(() => {
+            suite = createSuite('suite');
+            matcher = {a: 1};
+            matcher2 = {b: 2};
         });
 
-        it('should be false by default', function() {
-            assert.isFalse(this.suite.skipped);
+        it('should be false by default', () => {
+            assert.isFalse(suite.skipped);
         });
 
-        it('should be changed by skip(object) method', function() {
-            this.suite.skip(this.matcher);
-            assert.deepEqual(this.suite.skipped, [this.matcher]);
+        it('should be changed by skip(object) method', () => {
+            suite.skip(matcher);
+            assert.deepEqual(suite.skipped, [matcher]);
         });
 
-        it('should be inherited by children', function() {
-            this.suite.skip();
+        it('should be inherited by children', () => {
+            suite.skip();
 
-            var child = createSuite('child', this.suite);
+            const child = createSuite('child', suite);
             assert.isTrue(child.skipped);
         });
 
-        it('should merge multiple matchers together', function() {
-            this.suite.skip(this.matcher);
-            this.suite.skip(this.matcher2);
+        it('should merge multiple matchers together', () => {
+            suite.skip(matcher);
+            suite.skip(matcher2);
 
-            assert.deepEqual(this.suite.skipped, [this.matcher, this.matcher2]);
+            assert.deepEqual(suite.skipped, [matcher, matcher2]);
         });
 
-        it('should not override `true` by browser list', function() {
-            this.suite.skip();
-            this.suite.skip(this.matcher);
+        it('should not override `true` by browser list', () => {
+            suite.skip();
+            suite.skip(matcher);
 
-            assert.isTrue(this.suite.skipped);
+            assert.isTrue(suite.skipped);
         });
 
-        it('should override browser list by `true`', function() {
-            this.suite.skip(this.matcher);
-            this.suite.skip();
+        it('should override browser list by `true`', () => {
+            suite.skip(matcher);
+            suite.skip();
 
-            assert.isTrue(this.suite.skipped);
+            assert.isTrue(suite.skipped);
         });
 
-        it('should merge children list with parent', function() {
-            this.suite.skip(this.matcher);
-            var child = createSuite('child', this.suite);
-            child.skip(this.matcher2);
+        it('should merge children list with parent', () => {
+            suite.skip(matcher);
+            const child = createSuite('child', suite);
+            child.skip(matcher2);
 
-            assert.deepEqual(child.skipped, [this.matcher, this.matcher2]);
+            assert.deepEqual(child.skipped, [matcher, matcher2]);
         });
 
-        it('should not affect parent when calling .skip() on child', function() {
-            this.suite.skip(this.matcher);
-            var child = createSuite('child', this.suite);
-            child.skip(this.matcher2);
+        it('should not affect parent when calling .skip() on child', () => {
+            suite.skip(matcher);
+            const child = createSuite('child', suite);
+            child.skip(matcher2);
 
-            assert.deepEqual(this.suite.skipped, [this.matcher]);
-        });
-    });
-
-    describe('hasChildNamed', function() {
-        beforeEach(function() {
-            this.suite = createSuite('parent');
-            this.child = createSuite('has', this.suite);
-            this.suite.addChild(this.child);
-        });
-
-        it('should return true when suite has child of a given name', function() {
-            assert.isTrue(this.suite.hasChildNamed('has'));
-        });
-
-        it('should return false when suite has no child of a given name', function() {
-            assert.isFalse(this.suite.hasChildNamed('has no'));
+            assert.deepEqual(suite.skipped, [matcher]);
         });
     });
 
-    describe('hasStateNamed', function() {
-        beforeEach(function() {
-            this.suite = createSuite('suite');
-            this.suite.addState({name: 'has'});
+    describe('hasChildNamed', () => {
+        let suite;
+
+        beforeEach(() => {
+            suite = createSuite('parent');
+            const child = createSuite('has', suite);
+            suite.addChild(child);
         });
 
-        it('should return true when suite has state of a given name', function() {
-            assert.isTrue(this.suite.hasStateNamed('has'));
+        it('should return true when suite has child of a given name', () => {
+            assert.isTrue(suite.hasChildNamed('has'));
         });
 
-        it('should return true when suite has state of a given name', function() {
-            assert.isFalse(this.suite.hasStateNamed('has no'));
+        it('should return false when suite has no child of a given name', () => {
+            assert.isFalse(suite.hasChildNamed('has no'));
         });
     });
 
-    describe('fullName', function() {
-        beforeEach(function() {
-            this.parent = createSuite('parent');
-            this.child = createSuite('child', this.parent);
+    describe('hasStateNamed', () => {
+        let suite;
+
+        beforeEach(() => {
+            suite = createSuite('suite');
+            suite.addState({name: 'has'});
         });
 
-        it('should return name for top level suite', function() {
-            assert.equal(this.parent.fullName, 'parent');
+        it('should return true when suite has state of a given name', () => {
+            assert.isTrue(suite.hasStateNamed('has'));
         });
 
-        it('should concat own name with parents', function() {
-            assert.equal(this.child.fullName, 'parent child');
+        it('should return true when suite has state of a given name', () => {
+            assert.isFalse(suite.hasStateNamed('has no'));
+        });
+    });
+
+    describe('fullName', () => {
+        let parent;
+        let child;
+
+        beforeEach(() => {
+            parent = createSuite('parent');
+            child = createSuite('child', parent);
+        });
+
+        it('should return name for top level suite', () => {
+            assert.equal(parent.fullName, 'parent');
+        });
+
+        it('should concat own name with parents', () => {
+            assert.equal(child.fullName, 'parent child');
         });
     });
 

--- a/test/util.js
+++ b/test/util.js
@@ -91,6 +91,7 @@ function makeSuiteTree(sceleton, rootOpts) {
                 pushToTree_(val, makeStateStub(parent, {name: val}));
             } else {
                 var suite = makeSuiteStub({parent: parent, name: name});
+                parent.addChild(suite);
                 pushToTree_(name, suite);
                 mkTree_(val, suite);
             }

--- a/test/util.js
+++ b/test/util.js
@@ -1,8 +1,9 @@
 'use strict';
-var Browser = require('lib/browser'),
-    State = require('lib/state'),
-    Suite = require('lib/suite'),
-    _ = require('lodash');
+
+const Browser = require('lib/browser');
+const State = require('lib/state');
+const Suite = require('lib/suite');
+const _ = require('lodash');
 
 function makeBrowser(capabilities, config) {
     config = _.merge({}, {
@@ -17,7 +18,7 @@ function makeBrowser(capabilities, config) {
 
 function browserWithId(id) {
     return Browser.create({
-        id: id,
+        id,
         desiredCapabilities: {
             browserName: id
         }
@@ -26,12 +27,12 @@ function browserWithId(id) {
 
 function makeSuiteStub(opts) {
     opts = _.defaults(opts || {}, {
-        name: 'some-default-name_' + new Date().getTime(),
+        name: `some-default-name_${new Date().getTime()}`,
         url: 'some-default-url',
         states: []
     });
 
-    var suite = Suite.create(opts.name, opts.parent);
+    const suite = Suite.create(opts.name, opts.parent);
     suite.beforeActions = ['before', 'actions'];
     suite.afterActions = ['after', 'actions'];
 
@@ -50,7 +51,7 @@ function makeStateStub(suite, opts) {
     suite = suite || makeSuiteStub();
     opts = opts || {};
 
-    var state = new State(suite, opts.name || 'default-state-name');
+    const state = new State(suite, opts.name || 'default-state-name');
     state.shouldSkip = sinon.stub();
 
     suite.states.push(state);
@@ -81,16 +82,16 @@ function makeSuiteTree(sceleton, rootOpts) {
         browsers: ['default-browser1', 'default-browser2']
     });
 
-    var tree = {};
+    const tree = {};
     mkTree_(sceleton, makeSuiteStub(rootOpts));
     return tree;
 
     function mkTree_(sceleton, parent) {
-        _.forEach(sceleton, function(val, name) {
+        _.forEach(sceleton, (val, name) => {
             if (_.isString(val)) {
                 pushToTree_(val, makeStateStub(parent, {name: val}));
             } else {
-                var suite = makeSuiteStub({parent: parent, name: name});
+                const suite = makeSuiteStub({parent: parent, name: name});
                 parent.addChild(suite);
                 pushToTree_(name, suite);
                 mkTree_(val, suite);
@@ -106,8 +107,10 @@ function makeSuiteTree(sceleton, rootOpts) {
     }
 }
 
-exports.makeBrowser = makeBrowser;
-exports.browserWithId = browserWithId;
-exports.makeStateStub = makeStateStub;
-exports.makeSuiteStub = makeSuiteStub;
-exports.makeSuiteTree = makeSuiteTree;
+module.exports = {
+    makeBrowser,
+    browserWithId,
+    makeStateStub,
+    makeSuiteStub,
+    makeSuiteTree
+};


### PR DESCRIPTION
// cc @eGavr @tormozz48 

We need to redefine url for each browsers with plugin by subscribing on event. Without those changes suite tree will be shared  between all browsers and we can't extend url with different options (e.g. some/url?browser=firefox for firefox and some/url?browser=chrome for chrome). So we need to clone suite tree for each browser agent