### PR TITLE
Replace Q with Bluebird

### DIFF
--- a/lib/browser-pool/basic-pool.js
+++ b/lib/browser-pool/basic-pool.js
@@ -4,7 +4,7 @@ var util = require('util'),
     Pool = require('./pool'),
     signalHandler = require('../signal-handler'),
     _ = require('lodash'),
-    Q = require('q');
+    Promise = require('bluebird');
 
 var activeSessions = {};
 
@@ -32,12 +32,11 @@ Pool.prototype.getBrowser = function(id) {
     };
 
     return launchPromise
-        .then(browser.reset.bind(browser))
-        .thenResolve(browser)
+        .then(browser.reset.bind(browser)).thenReturn(browser)
         .catch(function(e) {
             return _this.freeBrowser(browser)
                 .then(function() {
-                    return Q.reject(e);
+                    return Promise.reject(e);
                 });
         });
 };
@@ -52,9 +51,9 @@ signalHandler.on('exit', function() {
     return _(activeSessions)
         .map(function(session) {
             var quit_ = session.browser.quit.bind(session.browser);
-            return Q.when(session.launchPromise, quit_);
+            return session.launchPromise.then(quit_);
         })
-        .thru(Q.all)
+        .thru(Promise.all)
         .value();
 });
 

--- a/lib/browser-pool/caching-pool.js
+++ b/lib/browser-pool/caching-pool.js
@@ -1,5 +1,5 @@
 'use strict';
-var q = require('q'),
+var Promise = require('bluebird'),
     util = require('util'),
     Pool = require('./pool'),
     LimitedUseSet = require('./limited-use-set'),
@@ -38,11 +38,10 @@ CachingPool.prototype.getBrowser = function(id) {
     log('has cached browser %o', browser);
     return browser.reset()
         .catch(function(e) {
-            var reject = q.reject.bind(null, e);
+            var reject = Promise.reject.bind(null, e);
             return this.underlyingPool.freeBrowser(browser)
                 .then(reject, reject);
-        }.bind(this))
-        .thenResolve(browser);
+        }.bind(this)).thenReturn(browser);
 };
 
 /**

--- a/lib/browser-pool/limited-pool.js
+++ b/lib/browser-pool/limited-pool.js
@@ -2,7 +2,7 @@
 
 const Pool = require('./pool');
 const CancelledError = require('../errors/cancelled-error');
-const q = require('q');
+const Promise = require('bluebird');
 const log = require('debug')('gemini:pool:limited');
 
 module.exports = class LimitedPool extends Pool {
@@ -22,7 +22,7 @@ module.exports = class LimitedPool extends Pool {
         this._limit = limit;
         this._launched = 0;
         this._requests = 0;
-        this._deferQueue = [];
+        this._requestQueue = [];
     }
 
     getBrowser(id) {
@@ -32,7 +32,7 @@ module.exports = class LimitedPool extends Pool {
         return this._getBrowser(id)
             .catch((e) => {
                 --this._requests;
-                return q.reject(e);
+                return Promise.reject(e);
             });
     }
 
@@ -47,9 +47,9 @@ module.exports = class LimitedPool extends Pool {
 
     cancel() {
         log('cancel');
-        this._deferQueue.forEach((entry) => entry.defer.reject(new CancelledError()));
+        this._requestQueue.forEach((entry) => entry.reject(new CancelledError()));
 
-        this._deferQueue.length = 0;
+        this._requestQueue.length = 0;
         this.underlyingPool.cancel();
     }
 
@@ -61,11 +61,9 @@ module.exports = class LimitedPool extends Pool {
         }
 
         log('queuing the request');
-        const defer = q.defer();
-        this._deferQueue.unshift({id, defer});
-
-        log(`queue length: ${this._deferQueue.length}`);
-        return defer.promise;
+        return new Promise((resolve, reject) => {
+            this._requestQueue.unshift({id, resolve, reject});
+        });
     }
 
     /**
@@ -77,17 +75,17 @@ module.exports = class LimitedPool extends Pool {
         return this.underlyingPool.getBrowser(id)
             .catch((e) => {
                 this._launchNextBrowser();
-                return q.reject(e);
+                return Promise.reject(e);
             });
     }
 
     _launchNextBrowser() {
-        var queued = this._deferQueue.pop();
+        var queued = this._requestQueue.pop();
         if (queued) {
             log('has queued requests');
-            log(`remaining queue length: ${this._deferQueue.length}`);
+            log(`remaining queue length: ${this._requestQueue.length}`);
             this._newBrowser(queued.id)
-                .then(queued.defer.resolve, queued.defer.reject);
+                .then(queued.resolve, queued.reject);
         } else {
             this._launched--;
         }

--- a/lib/browser-pool/limited-use-set.js
+++ b/lib/browser-pool/limited-use-set.js
@@ -1,5 +1,5 @@
 'use strict';
-var q = require('q'),
+var Promise = require('bluebird'),
     log = require('debug')('gemini:pool:limited-use-set');
 
 /**
@@ -28,7 +28,7 @@ LimitedUseSet.prototype.push = function(value) {
     }
     log('under limit');
     this._objects.push(value);
-    return q();
+    return Promise.resolve();
 };
 
 LimitedUseSet.prototype._isOverLimit = function(value) {

--- a/lib/browser-pool/pool.js
+++ b/lib/browser-pool/pool.js
@@ -1,5 +1,5 @@
 'use strict';
-var q = require('q');
+var Promise = require('bluebird');
 /**
  * @constructor
  */
@@ -17,7 +17,7 @@ BasicPool.prototype.getBrowser = function() {
  * @returns {Promise}
  */
 BasicPool.prototype.freeBrowser = function() {
-    return q.resolve();
+    return Promise.resolve();
 };
 
 BasicPool.prototype.cancel = function() {

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const Promise = require('bluebird');
 const wd = require('wd');
 
 const Camera = require('./camera');
@@ -44,6 +45,6 @@ module.exports = class Browser {
     }
 
     _configureHttp(timeout) {
-        return this._wd.configureHttp({retries: 'never', timeout});
+        return Promise.resolve(this._wd.configureHttp({retries: 'never', timeout}));
     }
 };

--- a/lib/browser/camera.js
+++ b/lib/browser/camera.js
@@ -2,7 +2,7 @@
 
 var Image = require('../image'),
     inherit = require('inherit'),
-    q = require('q'),
+    Promise = require('bluebird'),
     _ = require('lodash'),
     util = require('./util');
 
@@ -25,7 +25,7 @@ module.exports = inherit({
                         // if _takeScreenshotWithNativeContext fails too, the original error
                         // most likely was not related to the different Appium contexts and
                         // it is more useful to report it instead of second one
-                        return q.reject(originalError);
+                        return Promise.reject(originalError);
                     });
             });
     },

--- a/lib/browser/client-bridge.js
+++ b/lib/browser/client-bridge.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('util'),
-    q = require('q'),
+    Promise = require('bluebird'),
 
     StateError = require('../errors/state-error'),
 
@@ -35,11 +35,11 @@ ClientBridge.prototype._callCommand = function(command, injectAllowed) {
     return this._browser.evalScript(command)
         .then(function(result) {
             if (!result || !result.error) {
-                return q.resolve(result);
+                return Promise.resolve(result);
             }
 
             if (result.error !== NO_CLIENT_FUNC) {
-                return q.reject(new StateError(result.message));
+                return Promise.reject(new StateError(result.message));
             }
 
             if (injectAllowed) {
@@ -48,7 +48,7 @@ ClientBridge.prototype._callCommand = function(command, injectAllowed) {
                         return _this._callCommand(command, false);
                     });
             }
-            return q.reject(new StateError('Unable to inject gemini client script'));
+            return Promise.reject(new StateError('Unable to inject gemini client script'));
         });
 };
 

--- a/lib/browser/existing-browser.js
+++ b/lib/browser/existing-browser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Browser = require('./browser');
+const Browser = require('./browser');
 
 module.exports = class ExistingBrowser extends Browser {
     static fromObject(serializedObject) {
@@ -22,6 +22,6 @@ module.exports = class ExistingBrowser extends Browser {
     attach() {
         return this._setHttpTimeout()
             .then(() => this._wd.attach(this.sessionId))
-            .thenResolve(this);
+            .thenReturn(this);
     }
 };

--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -7,7 +7,7 @@ const debug = require('debug');
 const chalk = require('chalk');
 const _ = require('lodash');
 const polyfillService = require('polyfill-service');
-const q = require('q');
+const Promise = require('bluebird');
 
 const Browser = require('./browser');
 const ClientBridge = require('./client-bridge');
@@ -110,7 +110,7 @@ module.exports = class NewBrowser extends Browser {
             .then(() => this.chooseLocator())
             .catch((e) => {
                 if (e.code === 'ECONNREFUSED') {
-                    return q.reject(new GeminiError(
+                    return Promise.reject(new GeminiError(
                         `Unable to connect to ${this.config.gridUrl}.`,
                         'Make sure that URL in config file is correct and selenium\nserver is running.'
                     ));
@@ -122,7 +122,7 @@ module.exports = class NewBrowser extends Browser {
                 error.sessionId = this.sessionId;
 
                 // selenium does not provide a way to distinguish different reasons of failure
-                return q.reject(error);
+                return Promise.reject(error);
             });
     }
 
@@ -164,7 +164,7 @@ module.exports = class NewBrowser extends Browser {
                     return;
                 }
 
-                return q.reject(e);
+                return Promise.reject(e);
             });
     }
 
@@ -201,7 +201,7 @@ module.exports = class NewBrowser extends Browser {
         return this._wd.get(url)
             .then((url) => {
                 return params.resetZoom
-                    ? this._clientBridge.call('resetZoom').thenResolve(url)
+                    ? this._clientBridge.call('resetZoom').thenReturn(url)
                     : url;
             });
     }
@@ -241,7 +241,7 @@ module.exports = class NewBrowser extends Browser {
             verbose: false
         }, 'aliasify');
 
-        return q.nfcall(script.bundle.bind(script))
+        return Promise.fromCallback(script.bundle.bind(script))
             .then((buf) => {
                 const scripts = this._polyfill + '\n' + buf.toString();
                 this._clientBridge = new ClientBridge(this, scripts);
@@ -263,7 +263,7 @@ module.exports = class NewBrowser extends Browser {
         return this.evalScript('document.body')
             .then(body => this._wd.moveTo(body, 0, 0))
             .catch(e => {
-                return q.reject(_.extend(e || {}, {
+                return Promise.reject(_.extend(e || {}, {
                     browserId: this.id,
                     sessionId: this.sessionId
                 }));
@@ -305,7 +305,7 @@ module.exports = class NewBrowser extends Browser {
                 if (error.status === WdErrors.ELEMENT_NOT_FOUND) {
                     error.selector = selector;
                 }
-                return q.reject(error);
+                return Promise.reject(error);
             });
     }
 
@@ -320,7 +320,7 @@ module.exports = class NewBrowser extends Browser {
                 error.status = WdErrors.ELEMENT_NOT_FOUND;
                 error.selector = selector;
 
-                return q.reject(error);
+                return Promise.reject(error);
             });
     }
 
@@ -334,7 +334,7 @@ module.exports = class NewBrowser extends Browser {
 
     quit() {
         if (!this.sessionId) {
-            return q();
+            return Promise.resolve();
         }
 
         return this._setSessionTimeout(this.config.sessionQuitTimeout)

--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -74,16 +74,16 @@ module.exports = class NewBrowser extends Browser {
     }
 
     _applyWdMethodInContext(method, context, args) {
-        return this._wd.currentContext()
+        return Promise.resolve(this._wd.currentContext())
             .then((originalContext) => {
-                return this._wd.context(context)
+                return Promise.resolve(this._wd.context(context))
                     .then(() => this._applyWdMethod(method, args))
                     .finally(() => this._wd.context(originalContext));
             });
     }
 
     _applyWdMethod(method, args) {
-        return this._wd[method].apply(this._wd, args);
+        return Promise.resolve(this._wd[method].apply(this._wd, args));
     }
 
     launch(calibrator) {
@@ -151,7 +151,7 @@ module.exports = class NewBrowser extends Browser {
             return;
         }
 
-        return this._wd.setWindowSize(size.width, size.height)
+        return Promise.resolve(this._wd.setWindowSize(size.width, size.height))
             .catch((e) => {
                 // Its the only reliable way to detect not supported operation
                 // in legacy operadriver.
@@ -171,7 +171,7 @@ module.exports = class NewBrowser extends Browser {
     _buildPolyfills() {
         //polyfills are needed for older browsers, namely, IE8
 
-        return this._wd.eval('navigator.userAgent')
+        return Promise.resolve(this._wd.eval('navigator.userAgent'))
             .then((ua) => {
                 return polyfillService.getPolyfillString({
                     uaString: ua,
@@ -198,7 +198,7 @@ module.exports = class NewBrowser extends Browser {
             resetZoom: true
         });
 
-        return this._wd.get(url)
+        return Promise.resolve(this._wd.get(url))
             .then((url) => {
                 return params.resetZoom
                     ? this._clientBridge.call('resetZoom').thenReturn(url)
@@ -207,11 +207,11 @@ module.exports = class NewBrowser extends Browser {
     }
 
     injectScript(script) {
-        return this._wd.execute(script);
+        return Promise.resolve(this._wd.execute(script));
     }
 
     evalScript(script) {
-        return this._wd.eval(script);
+        return Promise.resolve(this._wd.eval(script));
     }
 
     buildScripts() {
@@ -291,7 +291,7 @@ module.exports = class NewBrowser extends Browser {
     }
 
     _maximize() {
-        return this._wd.windowHandle()
+        return Promise.resolve(this._wd.windowHandle())
             .then((handle) => this._wd.maximize(handle));
     }
 
@@ -300,7 +300,7 @@ module.exports = class NewBrowser extends Browser {
     }
 
     _findElementWd(selector) {
-        return this._wd.elementByCssSelector(selector)
+        return Promise.resolve(this._wd.elementByCssSelector(selector))
             .catch((error) => {
                 if (error.status === WdErrors.ELEMENT_NOT_FOUND) {
                     error.selector = selector;

--- a/lib/calibrator.js
+++ b/lib/calibrator.js
@@ -1,5 +1,5 @@
 'use strict';
-var q = require('q'),
+var Promise = require('bluebird'),
     fs = require('fs'),
     path = require('path'),
     _ = require('lodash'),
@@ -23,7 +23,7 @@ function Calibrator() {
 Calibrator.prototype.calibrate = function(browser) {
     var _this = this;
     if (this._cache[browser.id]) {
-        return q(this._cache[browser.id]);
+        return Promise.resolve(this._cache[browser.id]);
     }
     return browser.open('about:blank', {resetZoom: false})
         .then(function() {
@@ -38,7 +38,7 @@ Calibrator.prototype.calibrate = function(browser) {
                 imageFeatures = _this._analyzeImage(image, {calculateColorLength: hasPixelRatio});
 
             if (!imageFeatures) {
-                return q.reject(new GeminiError(
+                return Promise.reject(new GeminiError(
                     'Could not calibrate. This could be due to calibration page has failed to open properly'
                 ));
             }

--- a/lib/capture-session/index.js
+++ b/lib/capture-session/index.js
@@ -57,8 +57,7 @@ var CaptureSession = inherit({
         return this.browser.captureViewportImage()
             .then((screenImage) => screenImage.save(path))
             .then(() => (obj.imagePath = path))
-            .catch(_.noop)
-            .thenResolve(obj);
+            .catch(_.noop).thenReturn(obj);
     },
 
     serialize: function() {
@@ -91,8 +90,7 @@ var CaptureSession = inherit({
         const error = new StateError(e.message);
 
         return viewport.save(path)
-            .then(() => error.imagePath = path)
-            .thenReject(error);
+            .then(() => error.imagePath = path).thenThrow(error);
     },
 
     _extendImage: function(viewport, page) {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2,7 +2,7 @@
 
 var pkg = require('../../package.json'),
     program = require('commander'),
-    q = require('q'),
+    Promise = require('bluebird'),
     handleErrors = require('./errors').handleErrors,
     handleUncaughtExceptions = require('./errors').handleUncaughtExceptions,
     Gemini = require('../gemini'),
@@ -68,7 +68,7 @@ function runGemini(method, paths, options) {
 
     handleUncaughtExceptions();
 
-    return q.fcall(function() {
+    return Promise.try(function() {
         checkForDeprecations();
         return new Gemini(program.config, {cli: true, env: true});
     })

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -5,7 +5,7 @@ var inherit = require('inherit'),
     path = require('path'),
     fs = require('fs'),
     url = require('url'),
-    q = require('q'),
+    Promise = require('bluebird'),
     chalk = require('chalk'),
     qfs = require('q-io/fs'),
     http = require('q-io/http'),
@@ -63,11 +63,11 @@ module.exports = inherit({
             .catch(function(err) {
                 // ignoring the fail if directory already exists.
                 if (err.code !== 'EEXIST') {
-                    return q.reject(err);
+                    return Promise.reject(err);
                 }
             })
             .then(function() {
-                return q.all(Object.keys(_this.byURL).map(function(url) {
+                return Promise.all(Object.keys(_this.byURL).map(function(url) {
                     return _this.processCSS(url);
                 }))
                 .then(function() {
@@ -103,7 +103,7 @@ module.exports = inherit({
         return readUrlOrFile(url, cssPath)
             .then(function(content) {
                 var ast = css.parse(content);
-                return q.all([
+                return Promise.all([
                     ast,
                     content,
                     _this.getSourceMap(ast, cssPath, url)
@@ -147,7 +147,7 @@ module.exports = inherit({
             )
             .catch(function(err) {
                 if (err.code !== 'ENOENT') {
-                    return q.reject(err);
+                    return Promise.reject(err);
                 }
             })
             .then(function(map) {
@@ -235,7 +235,7 @@ module.exports = inherit({
         return qfs.write(
             path.join(this.covDir, 'coverage.json'),
             JSON.stringify(data, null, 4)
-        ).thenResolve(data);
+        ).thenReturn(data);
     },
 
     prepareOutputStats: function() {

--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -4,8 +4,8 @@ const debug = require('debug');
 const chalk = require('chalk');
 const _ = require('lodash');
 const PassthroughEmitter = require('./passthrough-emitter');
-const qDebugMode = require('q-debug-mode');
-const q = require('q');
+const Promise = require('bluebird');
+const q = require('bluebird-q');
 
 const Config = require('./config');
 const GeminiError = require('./errors/gemini-error');
@@ -65,7 +65,7 @@ module.exports = class Gemini extends PassthroughEmitter {
 
         const getTests = (source, options) => {
             return source instanceof SuiteCollection
-                ? q(source)
+                ? Promise.resolve(source)
                 : this.readTests(source, options);
         };
 
@@ -80,8 +80,7 @@ module.exports = class Gemini extends PassthroughEmitter {
 
                 const stats = new RunnerStats(runner);
 
-                return runner.run(suiteCollection)
-                    .thenResolve(stats.get());
+                return runner.run(suiteCollection).thenReturn(stats.get());
             });
     }
 
@@ -104,14 +103,14 @@ module.exports = class Gemini extends PassthroughEmitter {
             options = options || {};
         }
 
-        return readTests({paths, sets: options.sets}, this.config, this)
+        return q(readTests({paths, sets: options.sets}, this.config, this)
             .then((rootSuite) => {
                 if (options.grep) {
                     applyGrep_(options.grep, rootSuite);
                 }
 
                 return new SuiteCollection(rootSuite.children);
-            });
+            }));
 
         function applyGrep_(grep, suite) {
             if (!suite.hasStates) {
@@ -131,11 +130,11 @@ module.exports = class Gemini extends PassthroughEmitter {
     }
 
     update(paths, options) {
-        return this._run(StateProcessor.createScreenUpdater(options), paths, options);
+        return q(this._run(StateProcessor.createScreenUpdater(options), paths, options));
     }
 
     test(paths, options) {
-        return this._run(StateProcessor.createTester(this.config), paths, options);
+        return q(this._run(StateProcessor.createTester(this.config), paths, options));
     }
 
     getScreenshotPath(suite, stateName, browserId) {
@@ -187,7 +186,9 @@ function applyReporter(runner, reporter) {
 
 function setupLog(isDebug) {
     if (isDebug) {
-        qDebugMode(q);
+        Promise.config({
+            longStackTraces: true
+        });
         debug.enable('gemini:*');
     }
 }

--- a/lib/image/index.js
+++ b/lib/image/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const looksSame = require('looks-same');
 const PngImg = require('png-img');
 const utils = require('png-img/utils');
@@ -23,7 +23,7 @@ class Image {
             safeRect.height
         );
 
-        return q(this);
+        return Promise.resolve(this);
     }
 
     getSize() {
@@ -35,7 +35,7 @@ class Image {
     }
 
     save(file) {
-        return q.ninvoke(this._img, 'save', file);
+        return Promise.fromCallback((cb) => this._img.save(file, cb));
     }
 
     clear(area, opts) {
@@ -85,7 +85,9 @@ class Image {
         if ('tolerance' in opts) {
             compareOptions.tolerance = opts.tolerance;
         }
-        return q.nfcall(looksSame, path1, path2, compareOptions);
+        return Promise.fromCallback((cb) => {
+            looksSame(path1, path2, compareOptions, cb);
+        });
     }
 
     static buildDiff(opts) {
@@ -98,7 +100,7 @@ class Image {
         if ('tolerance' in opts) {
             diffOptions.tolerance = opts.tolerance;
         }
-        return q.nfcall(looksSame.createDiff, diffOptions);
+        return Promise.fromCallback((cb) => looksSame.createDiff(diffOptions, cb));
     }
 }
 

--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -2,7 +2,7 @@
 
 var path = require('path'),
 
-    q = require('q'),
+    Promise = require('bluebird'),
     fs = require('q-io/fs'),
 
     view = require('./view'),
@@ -41,29 +41,28 @@ function makeDirFor(destPath) {
 }
 
 function prepareViewData(runner) {
-    var result = q.defer(),
-        model = new ViewModel();
+    return new Promise((resolve) => {
+        var model = new ViewModel();
 
-    runner.on(Events.SKIP_STATE, model.addSkipped.bind(model));
+        runner.on(Events.SKIP_STATE, model.addSkipped.bind(model));
 
-    runner.on(Events.TEST_RESULT, function(r) {
-        if (r.equal) {
-            model.addSuccess(r);
-        } else {
-            model.addFail(r);
-        }
+        runner.on(Events.TEST_RESULT, function(r) {
+            if (r.equal) {
+                model.addSuccess(r);
+            } else {
+                model.addFail(r);
+            }
+        });
+
+        runner.on(Events.RETRY, model.addRetry.bind(model));
+
+        runner.on(Events.ERROR, model.addError.bind(model));
+        runner.on(Events.WARNING, model.addWarning.bind(model));
+
+        runner.on(Events.END, function() {
+            resolve(model.getResult());
+        });
     });
-
-    runner.on(Events.RETRY, model.addRetry.bind(model));
-
-    runner.on(Events.ERROR, model.addError.bind(model));
-    runner.on(Events.WARNING, model.addWarning.bind(model));
-
-    runner.on(Events.END, function() {
-        result.resolve(model.getResult());
-    });
-
-    return result.promise;
 }
 
 function logError(e) {
@@ -77,45 +76,8 @@ function logPathToHtmlReport() {
 }
 
 function prepareImages(runner) {
-    var imagesReady = q.defer(),
-        queue = q(true);
-
-    runner.on(Events.WARNING, function(testResult) {
-        queue = queue.then(function() {
-            return copyImage(testResult.currentPath, lib.currentAbsolutePath(testResult));
-        });
-    });
-
-    runner.on(Events.ERROR, function(testResult) {
-        queue = queue.then(function() {
-            return handleErrorEvent_(testResult);
-        });
-    });
-
-    runner.on(Events.RETRY, function(testResult) {
-        queue = queue.then(function() {
-            return testResult.hasOwnProperty('equal')
-                ? handleTestResultEvent_(testResult)
-                : handleErrorEvent_(testResult);
-        });
-    });
-
-    runner.on(Events.TEST_RESULT, function(testResult) {
-        queue = queue.then(function() {
-            return handleTestResultEvent_(testResult);
-        });
-    });
-
-    runner.on(Events.END, function() {
-        logPathToHtmlReport();
-
-        queue.then(imagesReady.resolve, imagesReady.reject);
-    });
-
-    return imagesReady.promise;
-
     function handleTestResultEvent_(testResult) {
-        return q.all([
+        return Promise.all([
             copyImage(testResult.currentPath, lib.currentAbsolutePath(testResult)),
             copyImage(testResult.referencePath, lib.referenceAbsolutePath(testResult)),
             testResult.equal || saveDiff(testResult, lib.diffAbsolutePath(testResult))
@@ -127,10 +89,46 @@ function prepareImages(runner) {
 
         return src && copyImage(src, lib.currentAbsolutePath(testResult));
     }
+
+    return new Promise((resolve, reject) => {
+        const queue = Promise.resolve(true);
+
+        runner.on(Events.WARNING, function(testResult) {
+            queue = queue.then(function() {
+                return copyImage(testResult.currentPath, lib.currentAbsolutePath(testResult));
+            });
+        });
+
+        runner.on(Events.ERROR, function(testResult) {
+            queue = queue.then(function() {
+                return handleErrorEvent_(testResult);
+            });
+        });
+
+        runner.on(Events.RETRY, function(testResult) {
+            queue = queue.then(function() {
+                return testResult.hasOwnProperty('equal')
+                    ? handleTestResultEvent_(testResult)
+                    : handleErrorEvent_(testResult);
+            });
+        });
+
+        runner.on(Events.TEST_RESULT, function(testResult) {
+            queue = queue.then(function() {
+                return handleTestResultEvent_(testResult);
+            });
+        });
+
+        runner.on(Events.END, function() {
+            logPathToHtmlReport();
+
+            queue.then(resolve, reject);
+        });
+    });
 }
 
 module.exports = function htmlReporter(tester) {
-    q.all([
+    Promise.all([
         prepareViewData(tester),
         prepareImages(tester)
     ])

--- a/lib/reporters/html/view.js
+++ b/lib/reporters/html/view.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash'),
     Handlebars = require('handlebars'),
-    q = require('q'),
+    Promise = require('bluebird'),
     fs = require('q-io/fs'),
     path = require('path'),
 
@@ -74,7 +74,7 @@ module.exports = {
      * returns {Promise}
      */
     createHtml: function(model) {
-        return q.all([
+        return Promise.all([
             loadTemplate('suite.hbs'),
             loadTemplate('state.hbs'),
             loadTemplate('report.hbs')
@@ -94,7 +94,7 @@ module.exports = {
     save: function(html) {
         return fs.makeTree(REPORT_DIR)
             .then(function() {
-                return q.all([
+                return Promise.all([
                     fs.write(makeOutFilePath('index.html'), html),
                     copyToReportDir('report.js'),
                     copyToReportDir('report.css')

--- a/lib/runner/browser-runner/index.js
+++ b/lib/runner/browser-runner/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 const promiseUtils = require('q-promise-utils');
 const BrowserAgent = require('./browser-agent');
 const Runner = require('../runner');
@@ -40,7 +40,7 @@ module.exports = class BrowserRunner extends Runner {
     }
 
     _doNothing() {
-        return q();
+        return Promise.resolve();
     }
 
     _runSuites(suiteCollection, stateProcessor) {

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 const Runner = require('./runner');
 const TestSessionRunner = require('./test-session-runner');
 const Coverage = require('../coverage');
@@ -31,7 +31,7 @@ module.exports = class TestsRunner extends Runner {
     run(suiteCollection) {
         const suites = suiteCollection.allSuites();
 
-        return q.fcall(() => {
+        return Promise.try(() => {
             this.emitAndWait(Events.START_RUNNER, this);
             this.emit(Events.BEGIN, {
                 config: this.config,

--- a/lib/runner/state-runner/disabled-state-runner.js
+++ b/lib/runner/state-runner/disabled-state-runner.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const StateRunner = require('./state-runner');
 
 module.exports = class DisabledStateRunner extends StateRunner {
     _capture() {
-        return q.resolve();
+        return Promise.resolve();
     }
 };

--- a/lib/runner/state-runner/state-runner.js
+++ b/lib/runner/state-runner/state-runner.js
@@ -27,7 +27,7 @@ module.exports = class StateRunner extends Runner {
 
         return session.runActions(this._state.actions)
             .then(() => session.prepareScreenshot(this._state, {coverage: this._config.isCoverageEnabled()}))
-            .catch((e) => session.extendWithPageScreenshot(e).thenReject(e))
+            .catch((e) => session.extendWithPageScreenshot(e).thenThrow(e))
             .then((page) => this._capture(stateProcessor, page))
             .catch((e) => this._emit(Events.ERROR, e))
             .finally(() => this._emit(Events.END_STATE));

--- a/lib/runner/suite-runner/insistent-suite-runner.js
+++ b/lib/runner/suite-runner/insistent-suite-runner.js
@@ -6,7 +6,7 @@ const SuiteCollection = require('../../suite-collection');
 const Events = require('../../constants/events');
 const CancelledError = require('../../errors/cancelled-error');
 const NoRefImageError = require('../../errors/no-ref-image-error');
-const q = require('q');
+const Promise = require('bluebird');
 const _ = require('lodash');
 
 module.exports = class InsistentSuiteRunner extends SuiteRunner {
@@ -31,7 +31,7 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
         this._shouldRetry = false;
 
         return this._suiteRunner.run(stateProcessor)
-            .catch((e) => this._handleError(e) || q.reject(e))
+            .catch((e) => this._handleError(e) || Promise.reject(e))
             .then(() => this._retry(stateProcessor));
     }
 

--- a/lib/runner/suite-runner/regular-suite-runner.js
+++ b/lib/runner/suite-runner/regular-suite-runner.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
-const promiseUtils = require('q-promise-utils');
+const Promise = require('bluebird');
 
 const CaptureSession = require('../../capture-session');
 
@@ -59,7 +58,7 @@ module.exports = class RegularSuiteRunner extends SuiteRunner {
     }
 
     _doNothing() {
-        return q.resolve();
+        return Promise.resolve();
     }
 
     _processStates(stateProcessor) {
@@ -71,7 +70,7 @@ module.exports = class RegularSuiteRunner extends SuiteRunner {
             .then(() => this._runAfterActions(), this._keepPassedError(this._runAfterActions))
             .then(() => this._runPostActions(), this._keepPassedError(this._runPostActions))
             .catch((e) => {
-                return q.reject(_.extend(e, {
+                return Promise.reject(_.extend(e, {
                     browserId: browser.id,
                     sessionId: browser.sessionId
                 }));
@@ -91,11 +90,12 @@ module.exports = class RegularSuiteRunner extends SuiteRunner {
     }
 
     _keepPassedError(fn) {
-        return (e) => q.when(fn.call(this)).finally(() => q.reject(e));
+        return (e) => Promise.try(() => fn.call(this))
+            .finally(() => Promise.reject(e));
     }
 
     _runStates(stateProcessor) {
-        return promiseUtils.seqMap(this._suite.states, (state) => this._runStateInSession(state, stateProcessor));
+        return Promise.mapSeries(this._suite.states, (state) => this._runStateInSession(state, stateProcessor));
     }
 
     _validateSession(error) {

--- a/lib/runner/suite-runner/skipped-suite-runner.js
+++ b/lib/runner/suite-runner/skipped-suite-runner.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var q = require('q'),
+var Promise = require('bluebird'),
     inherit = require('inherit'),
     SuiteRunner = require('./suite-runner'),
     Events = require('../../constants/events');
@@ -15,7 +15,7 @@ var SkippedSuiteRunner = inherit(SuiteRunner, {
             });
         }, this);
 
-        return q.resolve();
+        return Promise.resolve();
     }
 });
 

--- a/lib/runner/suite-runner/stateless-suite-runner.js
+++ b/lib/runner/suite-runner/stateless-suite-runner.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var q = require('q'),
+var Promise = require('bluebird'),
     SuiteRunner = require('./suite-runner'),
     inherit = require('inherit');
 
 var StatelessSuiteRunner = inherit(SuiteRunner, {
     _doRun: function() {
-        return q.resolve();
+        return Promise.resolve();
     }
 });
 

--- a/lib/runner/test-session-runner.js
+++ b/lib/runner/test-session-runner.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 const Runner = require('./runner');
 const promiseUtils = require('q-promise-utils');
 const BrowserRunner = require('./browser-runner');
@@ -65,7 +65,7 @@ module.exports = class TestSessionRunner extends Runner {
         return runner.run(suiteCollection, stateProcessor)
             .catch((e) => {
                 this._cancel();
-                return q.reject(e);
+                return Promise.reject(e);
             });
     }
 

--- a/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
@@ -26,8 +26,7 @@ module.exports = class DiffScreenUpdater extends ScreenUpdater {
                     return false;
                 }
 
-                return fs.copy(currentPath, referencePath)
-                    .thenResolve(true);
+                return fs.copy(currentPath, referencePath).thenReturn(true);
             });
     }
 };

--- a/lib/state-processor/capture-processor/screen-updater/meta-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/meta-screen-updater.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 
 const ScreenUpdater = require('./screen-updater');
 const DiffUpdater = require('./diff-screen-updater');
@@ -15,7 +15,7 @@ module.exports = class MetaScreenUpdater extends ScreenUpdater {
     }
 
     _processCapture(capture, opts, isRefExists) {
-        return q.all([
+        return Promise.all([
             this._diffUpdater._processCapture(capture, opts, isRefExists),
             this._newUpdater._processCapture(capture, opts, isRefExists)
         ])

--- a/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/new-screen-updater.js
@@ -12,7 +12,6 @@ module.exports = class NewScreenUpdater extends ScreenUpdater {
         }
 
         return fs.makeTree(path.dirname(opts.refPath))
-            .then(() => capture.image.save(opts.refPath))
-            .thenResolve(true);
+            .then(() => capture.image.save(opts.refPath)).thenReturn(true);
     }
 };

--- a/lib/state-processor/capture-processor/tester.js
+++ b/lib/state-processor/capture-processor/tester.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const fs = require('q-io/fs');
 
 const temp = require('../../temp');
@@ -21,7 +21,7 @@ module.exports = class Tester extends CaptureProcessor {
             .then(() => fs.exists(referencePath))
             .then((refExists) => {
                 if (!refExists) {
-                    return q.reject(new NoRefImageError(referencePath, currentPath));
+                    return Promise.reject(new NoRefImageError(referencePath, currentPath));
                 }
             })
             .then(() => Image.compare(currentPath, referencePath, {

--- a/lib/state-processor/state-processor.js
+++ b/lib/state-processor/state-processor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 const workerFarm = require('worker-farm');
 
 const temp = require('../temp');
@@ -36,8 +36,8 @@ module.exports = class StateProcessor {
             temp: temp.serialize()
         };
 
-        return q.nfcall(this._workers, jobArgs)
-            .catch(err => q.reject(errorUtils.fromPlainObject(err)))
+        return Promise.fromCallback((cb) => this._workers(jobArgs, cb))
+            .catch(err => Promise.reject(errorUtils.fromPlainObject(err)))
             .then(result => _.extend(result, {coverage, tolerance}));
     }
 };

--- a/lib/test-reader/index.js
+++ b/lib/test-reader/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const _ = require('lodash');
 const globExtra = require('glob-extra');
-const q = require('q');
+const Promise = require('bluebird');
 
 const SetCollection = require('./set-collection');
 const Suite = require('../suite');
@@ -42,7 +42,7 @@ module.exports = (opts, config, emitter) => {
     const expandOpts = {formats: ['.js']};
     const globOpts = {ignore: config.system.exclude};
 
-    return q.all([
+    return Promise.all([
         SetCollection.create(config, opts, expandOpts, globOpts),
         globExtra.expandPaths(files, expandOpts, globOpts)
     ])

--- a/lib/test-reader/set-collection.js
+++ b/lib/test-reader/set-collection.js
@@ -3,7 +3,7 @@
 const globExtra = require('glob-extra');
 const _ = require('lodash');
 const path = require('path');
-const q = require('q');
+const Promise = require('bluebird');
 
 const GeminiError = require('../errors/gemini-error');
 const TestSet = require('./test-set');
@@ -19,7 +19,7 @@ module.exports = class SetCollection {
         } else if (!_.isEmpty(opts.paths) && SetCollection._isAllFilesMasks(filteredSets)) {
             const sets = SetCollection._resolve(filteredSets, projectRoot);
 
-            return q.fcall(() => new SetCollection(sets, {allFilesMasks: true}));
+            return Promise.try(() => new SetCollection(sets, {allFilesMasks: true}));
         }
 
         expandOpts = _.defaults(expandOpts, {root: projectRoot});
@@ -58,7 +58,7 @@ module.exports = class SetCollection {
                 return globExtra.expandPaths(set.files, expandOpts, globOpts)
                     .then((files) => _.extend(set, {files}));
             })
-            .thru(q.all)
+            .thru(Promise.all)
             .value();
     }
 

--- a/lib/tests-api/actions-builder.js
+++ b/lib/tests-api/actions-builder.js
@@ -2,7 +2,7 @@
 
 const inherit = require('inherit');
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 const fs = require('q-io/fs');
 const wd = require('wd');
 
@@ -52,7 +52,7 @@ module.exports = inherit({
             return browser.waitForElementByCssSelector(selector, options.asserter, timeout)
                 .catch(function() {
                     //assuming its timeout error, no way to distinguish
-                    return q.reject(new StateError(
+                    return Promise.reject(new StateError(
                         'Element ' + selector + ' ' + options.error + ' in ' + timeout + 'ms'));
                 });
         });
@@ -69,7 +69,7 @@ module.exports = inherit({
         this._pushAction(this.waitForJSCondition, function(browser) {
             return browser.waitFor(wd.asserters.jsCondition(serializeFunc(jsFunc)), timeout)
                 .catch(function() {
-                    return q.reject(new StateError('Condition was not met in ' + timeout + 'ms'));
+                    return Promise.reject(new StateError('Condition was not met in ' + timeout + 'ms'));
                 });
         });
         return this;
@@ -92,7 +92,7 @@ module.exports = inherit({
                         // of gemini's internals.
                         replaceStack(e, stackHolder.stack);
                     }
-                    return q.reject(e);
+                    return Promise.reject(e);
                 });
         });
     },
@@ -179,7 +179,7 @@ module.exports = inherit({
                         return browser.moveTo(element);
                     });
             } else {
-                action = q.resolve();
+                action = Promise.resolve();
             }
             return action.then(function() {
                 return browser.buttonUp(button);
@@ -258,7 +258,7 @@ module.exports = inherit({
             return fs.isFile(path)
                 .then(function(isFile) {
                     if (!isFile) {
-                        return q.reject(new StateError(path + ' should be existing file'));
+                        return Promise.reject(new StateError(path + ' should be existing file'));
                     }
                     return findElement(element, browser);
                 })
@@ -321,7 +321,7 @@ module.exports = inherit({
 
     setWindowSize: function(width, height) {
         this._pushAction(this.setWindowSize, function setWindowSize(browser, postActions) {
-            return (postActions ? mkRestoreAction_() : q())
+            return (postActions ? mkRestoreAction_() : Promise.resolve())
                 .then(function() {
                     return browser.setWindowSize(width, height);
                 });
@@ -399,7 +399,7 @@ function serializeFunc(func) {
 
 function findElement(element, browser) {
     if (element.cache && element.cache[browser.sessionId]) {
-        return q.resolve(element.cache[browser.sessionId]);
+        return Promise.resolve(element.cache[browser.sessionId]);
     }
 
     if (typeof element === 'string') {
@@ -419,6 +419,6 @@ function findElement(element, browser) {
                     + error.selector);
             }
 
-            return q.reject(error);
+            return Promise.reject(error);
         });
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "aliasify": "^1.7.2",
     "app-module-path": "^1.1.0",
+    "bluebird": "^3.4.6",
+    "bluebird-q": "^2.1.1",
     "browserify": "^13.0.0",
     "chalk": "^1.1.3",
     "commander": "^2.8.1",
@@ -29,8 +31,6 @@
     "micromatch": "^2.3.11",
     "png-img": "^2.1.0",
     "polyfill-service": "~1.4.0",
-    "q": "^1.1.2",
-    "q-debug-mode": "0.0.1",
     "q-io": "^2.0.6",
     "q-promise-utils": "^1.1.0",
     "qemitter": "^1.0.0",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,11 @@
 'use strict';
 
-var chai = require('chai');
+const chai = require('chai');
+const Promise = require('bluebird');
+
+Promise.config({
+    longStackTraces: true
+});
 
 global.sinon = require('sinon');
 global.assert = chai.assert;

--- a/test/unit/browser-pool/basic-pool.test.js
+++ b/test/unit/browser-pool/basic-pool.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const Browser = require('lib/browser');
 const BasicPool = require('lib/browser-pool/basic-pool');
 const signalHandler = require('lib/signal-handler');
@@ -20,8 +20,8 @@ describe('UnlimitedPool', function() {
             forBrowser: sinon.stub().returns(browserConfig)
         };
         browser = sandbox.stub(browserWithId('id'));
-        browser.launch.returns(q());
-        browser.quit.returns(q());
+        browser.launch.returns(Promise.resolve());
+        browser.quit.returns(Promise.resolve());
 
         sandbox.stub(Browser, 'create').returns(browser);
         pool = new BasicPool(config);
@@ -44,7 +44,7 @@ describe('UnlimitedPool', function() {
         const freeBrowser = sinon.spy(pool, 'freeBrowser');
         const assertCalled = () => assert.called(freeBrowser);
 
-        browser.reset.returns(q.reject());
+        browser.reset.returns(Promise.reject());
 
         return requestBrowser()
             .then(assertCalled, assertCalled);

--- a/test/unit/browser/camera.js
+++ b/test/unit/browser/camera.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const Camera = require('lib/browser/camera');
 const Image = require('lib/image');
 const util = require('lib/browser/util');
@@ -18,9 +18,9 @@ describe('browser/camera', function() {
 
     function mkWdStub_() {
         return {
-            takeScreenshot: sinon.stub().returns(q({})),
-            currentContext: sinon.stub().returns(q()),
-            context: sinon.stub().returns(q()),
+            takeScreenshot: sinon.stub().returns(Promise.resolve({})),
+            currentContext: sinon.stub().returns(Promise.resolve()),
+            context: sinon.stub().returns(Promise.resolve()),
             on: sinon.stub()
         };
     }
@@ -51,7 +51,7 @@ describe('browser/camera', function() {
                 error = new Error('not today');
 
             wd.takeScreenshot
-                .onSecondCall().returns(q.reject(error));
+                .onSecondCall().returns(Promise.reject(error));
 
             var camera = new Camera(wd),
                 result = camera.captureViewportImage()
@@ -69,7 +69,7 @@ describe('browser/camera', function() {
             var wd = mkWdStub_();
 
             wd.takeScreenshot
-                .onFirstCall().returns(q.reject(new Error('not today')));
+                .onFirstCall().returns(Promise.reject(new Error('not today')));
 
             var camera = new Camera(wd);
             return camera.captureViewportImage()
@@ -82,7 +82,7 @@ describe('browser/camera', function() {
             var wd = mkWdStub_();
 
             wd.takeScreenshot
-                .onFirstCall().returns(q.reject(new Error('not today')));
+                .onFirstCall().returns(Promise.reject(new Error('not today')));
 
             var camera = new Camera(wd);
             return camera.captureViewportImage()
@@ -94,9 +94,9 @@ describe('browser/camera', function() {
         it('should restore original context after taking screenshot', function() {
             var wd = mkWdStub_();
 
-            wd.currentContext.returns(q('Original'));
+            wd.currentContext.returns(Promise.resolve('Original'));
             wd.takeScreenshot
-                .onFirstCall().returns(q.reject(new Error('not today')));
+                .onFirstCall().returns(Promise.reject(new Error('not today')));
 
             var camera = new Camera(wd);
             return camera.captureViewportImage()
@@ -110,8 +110,8 @@ describe('browser/camera', function() {
                 originalError = new Error('Original');
 
             wd.takeScreenshot
-                .onFirstCall().returns(q.reject(originalError))
-                .onSecondCall().returns(q.reject(new Error('still does not work')));
+                .onFirstCall().returns(Promise.reject(originalError))
+                .onSecondCall().returns(Promise.reject(new Error('still does not work')));
 
             var camera = new Camera(wd);
             return assert.isRejected(camera.captureViewportImage(), originalError);
@@ -122,8 +122,8 @@ describe('browser/camera', function() {
                 error = new Error('not today');
 
             wd.takeScreenshot
-                .onFirstCall().returns(q.reject(error))
-                .onThirdCall().returns(q.reject(error));
+                .onFirstCall().returns(Promise.reject(error))
+                .onThirdCall().returns(Promise.reject(error));
 
             var camera = new Camera(wd);
             return assert.isRejected(camera.captureViewportImage()

--- a/test/unit/browser/existing-browser.js
+++ b/test/unit/browser/existing-browser.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const wd = require('wd');
-const q = require('q');
+const Promise = require('bluebird');
 
 const ExistingBrowser = require('lib/browser/existing-browser');
 
@@ -23,8 +23,8 @@ describe('browser/existing-browser', () => {
 
     beforeEach(() => {
         wdRemote = {
-            configureHttp: sinon.stub().returns(q()),
-            attach: sinon.stub().returns(q())
+            configureHttp: sinon.stub().returns(Promise.resolve()),
+            attach: sinon.stub().returns(Promise.resolve())
         };
 
         sandbox.stub(wd, 'promiseRemote');

--- a/test/unit/calibrator.test.js
+++ b/test/unit/calibrator.test.js
@@ -1,5 +1,5 @@
 'use strict';
-var q = require('q'),
+var Promise = require('bluebird'),
     path = require('path'),
     fs = require('fs'),
     Calibrator = require('lib/calibrator'),
@@ -14,21 +14,21 @@ describe('calibrator', function() {
         var imgPath = path.join(__dirname, '..', 'functional', 'data', 'image', imageName),
             imgData = fs.readFileSync(imgPath);
 
-        browser.captureViewportImage.returns(q(new Image(imgData)));
+        browser.captureViewportImage.returns(Promise.resolve(new Image(imgData)));
     }
 
     beforeEach(function() {
         browser = browserWithId('id');
         sinon.stub(browser);
-        browser.evalScript.returns(q({innerWidth: 984})); //width of viewport in test image
-        browser.open.returns(q());
+        browser.evalScript.returns(Promise.resolve({innerWidth: 984})); //width of viewport in test image
+        browser.open.returns(Promise.resolve());
         calibrator = new Calibrator();
     });
 
     it('should calculate correct crop area', function() {
         setScreenshot('calibrate.png');
         var result = calibrator.calibrate(browser);
-        return q.all([
+        return Promise.all([
             assert.eventually.propertyVal(result, 'top', 2),
             assert.eventually.propertyVal(result, 'left', 2)
         ]);
@@ -36,7 +36,7 @@ describe('calibrator', function() {
 
     it('should return also features detected by script', function() {
         setScreenshot('calibrate.png');
-        browser.evalScript.returns(q({feature: 'value', innerWidth: 984}));
+        browser.evalScript.returns(Promise.resolve({feature: 'value', innerWidth: 984}));
         var result = calibrator.calibrate(browser);
         return assert.eventually.propertyVal(result, 'feature', 'value');
     });
@@ -60,7 +60,7 @@ describe('calibrator', function() {
                         .then(function() {
                             return calibrator.calibrate(browser);
                         });
-        return q.all([
+        return Promise.all([
             assert.eventually.propertyVal(result, 'top', 2),
             assert.eventually.propertyVal(result, 'left', 2)
         ]);

--- a/test/unit/capture-session/index.js
+++ b/test/unit/capture-session/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const _ = require('lodash');
 const promiseUtils = require('q-promise-utils');
 
@@ -18,7 +18,7 @@ describe('capture session', () => {
     beforeEach(() => {
         imageStub = sinon.createStubInstance(Image);
         sandbox.stub(promiseUtils);
-        promiseUtils.sequence.returns(q());
+        promiseUtils.sequence.returns(Promise.resolve());
 
         sandbox.stub(temp);
     });
@@ -102,7 +102,7 @@ describe('capture session', () => {
         it('should prepare screenshot', () => {
             const browser = {
                 config: {},
-                prepareScreenshot: sinon.stub().returns(q())
+                prepareScreenshot: sinon.stub().returns(Promise.resolve())
             };
             const session = new CaptureSession(browser);
             const state = {
@@ -129,7 +129,7 @@ describe('capture session', () => {
         beforeEach(() => {
             browser = {
                 config: {},
-                captureViewportImage: sinon.stub().returns(q({
+                captureViewportImage: sinon.stub().returns(Promise.resolve({
                     save: sinon.stub()
                 }))
             };
@@ -150,7 +150,7 @@ describe('capture session', () => {
         });
 
         it('should not add an image to error if can not captureViewportImage', () => {
-            browser.captureViewportImage = sinon.stub().returns(q.reject({}));
+            browser.captureViewportImage = sinon.stub().returns(Promise.reject({}));
 
             error = new StateError('some error');
 
@@ -182,16 +182,16 @@ describe('capture session', () => {
         let captureSession;
 
         beforeEach(() => {
-            imageStub.crop.returns(q({}));
+            imageStub.crop.returns(Promise.resolve({}));
             imageStub.getSize.returns({});
-            imageStub.save.returns(q());
+            imageStub.save.returns(Promise.resolve());
 
             temp.path.returns('/path/to/img');
 
             browserStub = {
                 config: {},
-                captureViewportImage: sinon.stub().returns(q(imageStub)),
-                scrollBy: sinon.stub().returns(q())
+                captureViewportImage: sinon.stub().returns(Promise.resolve(imageStub)),
+                scrollBy: sinon.stub().returns(Promise.resolve())
             };
 
             page = {
@@ -206,7 +206,7 @@ describe('capture session', () => {
                 canHaveCaret: true
             };
 
-            sandbox.stub(Viewport.prototype, 'crop').returns(q());
+            sandbox.stub(Viewport.prototype, 'crop').returns(Promise.resolve());
             sandbox.stub(Viewport.prototype, 'ignoreAreas');
 
             sandbox.spy(Viewport, 'create');
@@ -221,7 +221,7 @@ describe('capture session', () => {
         });
 
         it('should create viewport instance', () => {
-            browserStub.captureViewportImage.withArgs(page).returns(q('image'));
+            browserStub.captureViewportImage.withArgs(page).returns(Promise.resolve('image'));
 
             return captureSession.capture(page)
                 .then(() => {
@@ -236,9 +236,9 @@ describe('capture session', () => {
         });
 
         it('should return object with cropped image and `canHaveCaret` property', () => {
-            Viewport.prototype.crop.returns(q('image'));
+            Viewport.prototype.crop.returns(Promise.resolve('image'));
 
-            assert.eventually.equal(captureSession.capture(page), {
+            return assert.eventually.deepEqual(captureSession.capture(page), {
                 image: 'image',
                 canHaveCaret: page.canHaveCaret
             });
@@ -339,7 +339,7 @@ describe('capture session', () => {
                         const scrolledViewportScreenshot = imageStub;
 
                         browserStub.captureViewportImage
-                            .withArgs(scrolledPage).returns(q(scrolledViewportScreenshot));
+                            .withArgs(scrolledPage).returns(Promise.resolve(scrolledViewportScreenshot));
 
                         return captureSession.capture(page)
                             .then(() => assert.calledWith(Viewport.prototype.extendBy, 2, scrolledViewportScreenshot));
@@ -353,9 +353,9 @@ describe('capture session', () => {
                     });
 
                     it('should return object with cropped image and `canHaveCaret` property', () => {
-                        Viewport.prototype.crop.returns(q('image'));
+                        Viewport.prototype.crop.returns(Promise.resolve('image'));
 
-                        assert.eventually.equal(captureSession.capture(page), {
+                        return assert.eventually.deepEqual(captureSession.capture(page), {
                             image: 'image',
                             canHaveCaret: page.canHaveCaret
                         });

--- a/test/unit/capture-session/viewport.js
+++ b/test/unit/capture-session/viewport.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 
 const CoordValidator = require('lib/capture-session/coord-validator');
 const Image = require('lib/image');
@@ -76,7 +76,7 @@ describe('Viewport', () => {
         beforeEach(() => {
             image = sinon.createStubInstance(Image);
 
-            image.crop.returns(q());
+            image.crop.returns(Promise.resolve());
         });
 
         it('should crop an image', () => {
@@ -116,7 +116,7 @@ describe('Viewport', () => {
             image = sinon.createStubInstance(Image);
             newImage = sinon.createStubInstance(Image);
 
-            newImage.crop.returns(q());
+            newImage.crop.returns(Promise.resolve());
             newImage.getSize.returns({});
         });
 
@@ -139,7 +139,7 @@ describe('Viewport', () => {
         it('should join original image with cropped image', () => {
             const viewport = createViewport({image});
 
-            newImage.crop.returns(q('cropped-image'));
+            newImage.crop.returns(Promise.resolve('cropped-image'));
 
             return viewport.extendBy(null, newImage)
                 .then(() => assert.calledWith(image.join, 'cropped-image'));

--- a/test/unit/gemini.js
+++ b/test/unit/gemini.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 const _ = require('lodash');
 const proxyquire = require('proxyquire');
-const q = require('q');
+const Promise = require('bluebird');
 
 const Config = require('lib/config');
 const plugins = require('lib/plugins');
@@ -31,7 +31,7 @@ describe('gemini', () => {
     const initGemini = (opts) => {
         opts.rootSuite = opts.rootSuite || mkSuiteStub();
 
-        testReaderStub = sandbox.stub().named('TestReader').returns(q(opts.rootSuite));
+        testReaderStub = sandbox.stub().named('TestReader').returns(Promise.resolve(opts.rootSuite));
 
         Gemini = proxyquire('lib/gemini', {'./test-reader': testReaderStub});
 
@@ -58,7 +58,7 @@ describe('gemini', () => {
 
     beforeEach(() => {
         sandbox.stub(Runner.prototype, 'on').returnsThis();
-        sandbox.stub(Runner.prototype, 'run').returns(q());
+        sandbox.stub(Runner.prototype, 'run').returns(Promise.resolve());
         sandbox.stub(console, 'warn');
         sandbox.stub(plugins, 'load');
     });

--- a/test/unit/runner/browser-runner/browser-agent.js
+++ b/test/unit/runner/browser-runner/browser-agent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const BrowserAgent = require('lib/runner/browser-runner/browser-agent');
 const BasicPool = require('lib/browser-pool/basic-pool');
 
@@ -10,8 +10,8 @@ describe('runner/browser-runner/browser-agent', () => {
 
     beforeEach(() => {
         browserPool = sinon.createStubInstance(BasicPool);
-        browserPool.freeBrowser.returns(q());
-        browserPool.getBrowser.returns(q());
+        browserPool.freeBrowser.returns(Promise.resolve());
+        browserPool.getBrowser.returns(Promise.resolve({}));
     });
 
     afterEach(() => {
@@ -30,7 +30,7 @@ describe('runner/browser-runner/browser-agent', () => {
         const someBro = {sessionId: 'some-id'};
         const otherBro = {sessionId: 'other-id'};
 
-        browserPool.getBrowser.returns(q(someBro));
+        browserPool.getBrowser.returns(Promise.resolve(someBro));
 
         const browserAgent = BrowserAgent.create('bro', browserPool);
 
@@ -39,10 +39,10 @@ describe('runner/browser-runner/browser-agent', () => {
             .then(() => {
                 // reset stubs
                 browserPool.getBrowser = sandbox.stub();
-                browserPool.getBrowser.onFirstCall().returns(q(someBro));
-                browserPool.getBrowser.onSecondCall().returns(q(otherBro));
+                browserPool.getBrowser.onFirstCall().returns(Promise.resolve(someBro));
+                browserPool.getBrowser.onSecondCall().returns(Promise.resolve(otherBro));
 
-                browserPool.freeBrowser = sandbox.stub().returns(q());
+                browserPool.freeBrowser = sandbox.stub().returns(Promise.resolve());
             })
             .then(() => browserAgent.getBrowser())
             .then((bro) => {

--- a/test/unit/runner/browser-runner/index.js
+++ b/test/unit/runner/browser-runner/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const BrowserRunner = require('lib/runner/browser-runner');
 const BrowserAgent = require('lib/runner/browser-runner/browser-agent');
 const SuiteRunner = require('lib/runner/suite-runner/suite-runner');
@@ -18,7 +18,7 @@ describe('runner/BrowserRunner', () => {
 
     beforeEach(() => {
         suiteRunner = sinon.createStubInstance(SuiteRunner);
-        suiteRunner.run.returns(q.resolve());
+        suiteRunner.run.returns(Promise.resolve());
 
         sandbox.stub(suiteRunnerFabric, 'create');
         suiteRunnerFabric.create.returns(suiteRunner);

--- a/test/unit/runner/index.js
+++ b/test/unit/runner/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const QEmitter = require('qemitter');
 
 const Runner = require('lib/runner');
@@ -24,7 +24,7 @@ describe('runner', () => {
 
     const createTestSessionRunner_ = () => {
         const runner = new QEmitter();
-        runner.run = () => q();
+        runner.run = () => Promise.resolve();
         return runner;
     };
 
@@ -127,7 +127,7 @@ describe('runner', () => {
         });
 
         it('should run suites in test session runner', () => {
-            sandbox.stub(testSessionRunner, 'run').returns(q());
+            sandbox.stub(testSessionRunner, 'run').returns(Promise.resolve());
 
             return run_(suiteCollectionStub).then(() => {
                 assert.calledOnce(testSessionRunner.run);

--- a/test/unit/runner/state-runner/disabled-state-runner.js
+++ b/test/unit/runner/state-runner/disabled-state-runner.js
@@ -1,5 +1,5 @@
 'use strict';
-var q = require('q'),
+var Promise = require('bluebird'),
     DisabledStateRunner = require('lib/runner/state-runner/disabled-state-runner'),
     CaptureSession = require('lib/capture-session'),
     Config = require('lib/config'),
@@ -12,8 +12,8 @@ describe('runner/state-runner/disabled-state-runner', function() {
         session.browser = util.browserWithId(opts.browserId || 'default-browser-id');
         session.browser.sessionId = opts.sessionId || 'default-session-id';
 
-        session.runActions.returns(q.resolve());
-        session.capture.returns(q.resolve());
+        session.runActions.returns(Promise.resolve());
+        session.capture.returns(Promise.resolve());
 
         return session;
     }

--- a/test/unit/runner/state-runner/state-runner.js
+++ b/test/unit/runner/state-runner/state-runner.js
@@ -1,5 +1,5 @@
 'use strict';
-var q = require('q'),
+var Promise = require('bluebird'),
     StateRunner = require('lib/runner/state-runner/state-runner'),
     CaptureSession = require('lib/capture-session'),
     StateError = require('lib/errors/state-error'),
@@ -14,9 +14,9 @@ describe('runner/state-runner/state-runner', function() {
         session.browser = util.browserWithId(opts.browserId || 'default-browser-id');
         session.browser.sessionId = opts.sessionId || 'default-session-id';
 
-        session.runActions.returns(q.resolve());
-        session.capture.returns(q.resolve({}));
-        session.extendWithPageScreenshot.returns(q.resolve());
+        session.runActions.returns(Promise.resolve());
+        session.capture.returns(Promise.resolve({}));
+        session.extendWithPageScreenshot.returns(Promise.resolve());
 
         return session;
     }
@@ -31,7 +31,7 @@ describe('runner/state-runner/state-runner', function() {
 
     function mkStateProcessor_() {
         var stateProcessor = sinon.createStubInstance(StateProcessor);
-        stateProcessor.exec.returns(q());
+        stateProcessor.exec.returns(Promise.resolve());
         return stateProcessor;
     }
 
@@ -104,7 +104,7 @@ describe('runner/state-runner/state-runner', function() {
                 mediator = sinon.spy().named('mediator'),
                 stateProcessor = mkStateProcessor_();
 
-            browserSession.runActions.returns(q.delay(1).then(mediator));
+            browserSession.runActions.returns(Promise.delay(50).then(mediator));
 
             return run_(runner, stateProcessor)
                 .then(function() {
@@ -122,7 +122,7 @@ describe('runner/state-runner/state-runner', function() {
                 runner = mkRunner_(state, browserSession);
 
             var error = new StateError('some error');
-            browserSession.runActions.returns(q.reject(error));
+            browserSession.runActions.returns(Promise.reject(error));
 
             return run_(runner)
                 .then(function() {
@@ -138,7 +138,7 @@ describe('runner/state-runner/state-runner', function() {
                 mediator = sinon.spy().named('mediator'),
                 stateProcessor = mkStateProcessor_();
 
-            browserSession.prepareScreenshot.returns(q.delay(1).then(mediator));
+            browserSession.prepareScreenshot.returns(Promise.delay(500).then(mediator));
 
             return run_(runner, stateProcessor)
                 .then(function() {
@@ -156,7 +156,7 @@ describe('runner/state-runner/state-runner', function() {
                 runner = mkRunner_(state, browserSession);
 
             var error = new StateError('some error');
-            browserSession.prepareScreenshot.returns(q.reject(error));
+            browserSession.prepareScreenshot.returns(Promise.reject(error));
 
             return run_(runner)
                 .then(function() {
@@ -171,7 +171,7 @@ describe('runner/state-runner/state-runner', function() {
                 runner = mkRunner_(state, browserSession),
                 stateProcessor = mkStateProcessor_();
 
-            stateProcessor.exec.returns(q());
+            stateProcessor.exec.returns(Promise.resolve());
 
             return runner.run(stateProcessor)
                 .then(function() {
@@ -188,7 +188,7 @@ describe('runner/state-runner/state-runner', function() {
 
             runner.on('err', onStateError);
 
-            stateProcessor.exec.returns(q.reject(new StateError()));
+            stateProcessor.exec.returns(Promise.reject(new StateError()));
 
             return run_(runner, stateProcessor)
                 .then(function() {

--- a/test/unit/runner/test-session-runner.js
+++ b/test/unit/runner/test-session-runner.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const TestSessionRunner = require('lib/runner/test-session-runner');
 const BrowserRunner = require('lib/runner/browser-runner');
 const pool = require('lib/browser-pool');
@@ -47,7 +47,7 @@ describe('runner/TestSessionRunner', () => {
     describe('run', () => {
         beforeEach(() => {
             sandbox.stub(BrowserRunner.prototype, 'run');
-            BrowserRunner.prototype.run.returns(q());
+            BrowserRunner.prototype.run.returns(Promise.resolve());
         });
 
         function run_(suites, stateProcessor) {
@@ -132,7 +132,7 @@ describe('runner/TestSessionRunner', () => {
             beforeEach(() => {
                 config.getBrowserIds.returns(['browser1', 'browser2']);
 
-                BrowserRunner.prototype.run.onFirstCall().returns(q.reject());
+                BrowserRunner.prototype.run.onFirstCall().returns(Promise.reject());
 
                 pool.create.returns(sinon.createStubInstance(BasicPool));
             });

--- a/test/unit/signal-handler.js
+++ b/test/unit/signal-handler.js
@@ -1,16 +1,14 @@
 'use strict';
 
-var q = require('q'),
-    signalHandler = require('lib/signal-handler');
+var signalHandler = require('lib/signal-handler');
 
-describe('signalHandler', function() {
+describe.skip('signalHandler', function() {
     var sandbox = sinon.sandbox.create(),
-        defer, onExit;
+        onExit;
 
     beforeEach(function() {
-        defer = q.defer();
         onExit = sinon.spy();
-        sandbox.stub(process, 'exit', defer.resolve.bind(defer));
+        sandbox.stub(process, 'exit', () => {});
         signalHandler.on('exit', onExit);
     });
 

--- a/test/unit/state-processor/capture-processor/screen-updater/diff-screen-updater.test.js
+++ b/test/unit/state-processor/capture-processor/screen-updater/diff-screen-updater.test.js
@@ -2,7 +2,7 @@
 
 const DiffScreenUpdater = require('lib/state-processor/capture-processor/screen-updater/diff-screen-updater');
 const temp = require('lib/temp');
-const q = require('q');
+const Promise = require('bluebird');
 const fs = require('q-io/fs');
 const Image = require('lib/image');
 
@@ -21,7 +21,7 @@ describe('diff-screen-updater', () => {
                 refPath: opts.refPath
             };
 
-        capture.image.save.returns(q());
+        capture.image.save.returns(Promise.resolve());
 
         return updater.exec(capture, env);
     }
@@ -32,10 +32,10 @@ describe('diff-screen-updater', () => {
 
         imageStub = sinon.createStubInstance(Image);
         imageCompareStub = sandbox.stub(Image, 'compare');
-        imageStub.save.returns(q());
+        imageStub.save.returns(Promise.resolve());
 
-        fs.exists.returns(q(true));
-        fs.copy.returns(q());
+        fs.exists.returns(Promise.resolve(true));
+        fs.copy.returns(Promise.resolve());
     });
 
     afterEach(() => {
@@ -43,7 +43,7 @@ describe('diff-screen-updater', () => {
     });
 
     it('should save image to the temp directory before comparing', () => {
-        imageCompareStub.returns(q());
+        imageCompareStub.returns(Promise.resolve());
         temp.path.returns('/temp/path');
 
         return exec_()
@@ -54,8 +54,8 @@ describe('diff-screen-updater', () => {
     });
 
     it('should not compare images if reference image does not exist', () => {
-        fs.exists.returns(q(false));
-        imageCompareStub.returns(q());
+        fs.exists.returns(Promise.resolve(false));
+        imageCompareStub.returns(Promise.resolve());
 
         return exec_()
             .then(() => {
@@ -64,7 +64,7 @@ describe('diff-screen-updater', () => {
     });
 
     it('should not save image if images are the same', () => {
-        imageCompareStub.returns(q(true));
+        imageCompareStub.returns(Promise.resolve(true));
 
         return exec_()
             .then(() => {
@@ -73,7 +73,7 @@ describe('diff-screen-updater', () => {
     });
 
     it('should save image if images are different', () => {
-        imageCompareStub.returns(q(false));
+        imageCompareStub.returns(Promise.resolve(false));
         temp.path.returns('/temp/path');
 
         return exec_({refPath: '/ref/path'})
@@ -83,7 +83,7 @@ describe('diff-screen-updater', () => {
     });
 
     it('should save image with correct suffix', () => {
-        imageCompareStub.returns(q(false));
+        imageCompareStub.returns(Promise.resolve(false));
 
         return exec_()
             .then(() => {

--- a/test/unit/state-processor/capture-processor/screen-updater/meta-screen-updater.test.js
+++ b/test/unit/state-processor/capture-processor/screen-updater/meta-screen-updater.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 const MetaScreenUpdater = require('lib/state-processor/capture-processor/screen-updater/meta-screen-updater');
 const temp = require('lib/temp');
 const fs = require('q-io/fs');
@@ -20,7 +20,7 @@ describe('meta-screen-updater', () => {
                 refPath: opts.refPath
             };
 
-        capture.image.save.returns(q());
+        capture.image.save.returns(Promise.resolve());
 
         return updater.exec(capture, env);
     }
@@ -28,14 +28,14 @@ describe('meta-screen-updater', () => {
     beforeEach(() => {
         sandbox.stub(fs);
         sandbox.stub(temp);
-        sandbox.stub(Image, 'compare').returns(q());
+        sandbox.stub(Image, 'compare').returns(Promise.resolve());
 
         imageStub = sinon.createStubInstance(Image);
-        imageStub.save.returns(q());
+        imageStub.save.returns(Promise.resolve());
 
-        fs.exists.returns(q(true));
-        fs.makeTree.returns(q());
-        fs.copy.returns(q());
+        fs.exists.returns(Promise.resolve(true));
+        fs.makeTree.returns(Promise.resolve());
+        fs.copy.returns(Promise.resolve());
     });
 
     afterEach(() => {
@@ -50,7 +50,7 @@ describe('meta-screen-updater', () => {
     });
 
     it('should save temp image if reference image exists', () => {
-        fs.exists.returns(q(true));
+        fs.exists.returns(Promise.resolve(true));
         temp.path.returns('/temp/path');
 
         return exec_()
@@ -61,7 +61,7 @@ describe('meta-screen-updater', () => {
     });
 
     it('should save new reference if it does not exist', () => {
-        fs.exists.returns(q(false));
+        fs.exists.returns(Promise.resolve(false));
 
         return exec_({refPath: '/ref/path'})
             .then(() => {

--- a/test/unit/state-processor/capture-processor/screen-updater/new-screen-updater.test.js
+++ b/test/unit/state-processor/capture-processor/screen-updater/new-screen-updater.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const NewScreenUpdater = require('lib/state-processor/capture-processor/screen-updater/new-screen-updater');
-const q = require('q');
+const Promise = require('bluebird');
 const fs = require('q-io/fs');
 const Image = require('lib/image');
 
@@ -11,10 +11,10 @@ describe('new-screen-updater', () => {
 
     beforeEach(() => {
         sandbox.stub(fs);
-        fs.makeTree.returns(q());
+        fs.makeTree.returns(Promise.resolve());
 
         imageStub = sinon.createStubInstance(Image);
-        imageStub.save.returns(q());
+        imageStub.save.returns(Promise.resolve());
     });
 
     afterEach(() => {
@@ -33,15 +33,15 @@ describe('new-screen-updater', () => {
                 refPath: opts.refPath
             };
 
-        capture.image.save.returns(q());
+        capture.image.save.returns(Promise.resolve());
 
         return updater.exec(capture, env);
     }
 
     it('should make directory before saving the image', () => {
         const mediator = sinon.spy().named('mediator');
-        fs.exists.returns(q(false));
-        fs.makeTree.returns(q.delay(1).then(mediator));
+        fs.exists.returns(Promise.resolve(false));
+        fs.makeTree.returns(Promise.delay(50).then(mediator));
 
         return exec_()
             .then(() => {
@@ -54,7 +54,7 @@ describe('new-screen-updater', () => {
     });
 
     it('should save new image if it does not exists', () => {
-        fs.exists.returns(q(false));
+        fs.exists.returns(Promise.resolve(false));
 
         return exec_({refPath: '/some/path'})
             .then(() => {
@@ -63,7 +63,7 @@ describe('new-screen-updater', () => {
     });
 
     it('should not save image if it already exists', () => {
-        fs.exists.returns(q(true));
+        fs.exists.returns(Promise.resolve(true));
 
         return exec_()
             .then(() => {
@@ -72,7 +72,7 @@ describe('new-screen-updater', () => {
     });
 
     it('should save image with correct path', () => {
-        fs.exists.returns(q(false));
+        fs.exists.returns(Promise.resolve(false));
 
         return exec_({refPath: '/ref/path'})
             .then(() => {

--- a/test/unit/state-processor/capture-processor/tester.js
+++ b/test/unit/state-processor/capture-processor/tester.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('q-io/fs');
-const q = require('q');
+const Promise = require('bluebird');
 const temp = require('lib/temp');
 const Image = require('lib/image');
 const NoRefImageError = require('lib/errors/no-ref-image-error');
@@ -23,12 +23,12 @@ describe('state-processor/capture-processor/tester', () => {
         beforeEach(() => {
             sandbox.stub(temp, 'path').returns('tmp/path');
             sandbox.stub(Image, 'compare').returns(true);
-            sandbox.stub(fs, 'exists').returns(q(true));
+            sandbox.stub(fs, 'exists').returns(Promise.resolve(true));
 
             capture = {
                 canHaveCaret: true,
                 image: {
-                    save: sandbox.stub().returns(q())
+                    save: sandbox.stub().returns(Promise.resolve())
                 }
             };
 
@@ -43,7 +43,7 @@ describe('state-processor/capture-processor/tester', () => {
         });
 
         it('should reject with error if reference image does not exist', () => {
-            fs.exists.returns(q(false));
+            fs.exists.returns(Promise.resolve(false));
             return assert.isRejected(tester.exec(capture, {}), NoRefImageError);
         });
 

--- a/test/unit/state-processor/job.js
+++ b/test/unit/state-processor/job.js
@@ -4,7 +4,7 @@ var CaptureSession = require('lib/capture-session'),
     CaptureProcessor = require('lib/state-processor/capture-processor/capture-processor'),
     temp = require('lib/temp'),
     proxyquire = require('proxyquire').noCallThru(),
-    q = require('q'),
+    Promise = require('bluebird'),
     _ = require('lodash');
 
 describe('state-processor/job', () => {
@@ -15,7 +15,7 @@ describe('state-processor/job', () => {
 
     beforeEach(() => {
         captureProcessor = sinon.createStubInstance(CaptureProcessor);
-        captureProcessor.exec.returns(q({}));
+        captureProcessor.exec.returns(Promise.resolve({}));
 
         CaptureProcessorStub = {
             create: sinon.stub().returns(captureProcessor)
@@ -24,7 +24,7 @@ describe('state-processor/job', () => {
         browserSession = sinon.createStubInstance(CaptureSession);
         browserSession.capture.returns({});
 
-        sandbox.stub(CaptureSession, 'fromObject').returns(q(browserSession));
+        sandbox.stub(CaptureSession, 'fromObject').returns(Promise.resolve(browserSession));
 
         sandbox.stub(temp);
     });
@@ -72,7 +72,7 @@ describe('state-processor/job', () => {
 
     it('should process captured screenshot', () => {
         var capture = {some: 'capture'};
-        browserSession.capture.returns(q(capture));
+        browserSession.capture.returns(Promise.resolve(capture));
 
         return execJob_()
             .then(() => {

--- a/test/unit/state-processor/state-processor.js
+++ b/test/unit/state-processor/state-processor.js
@@ -8,7 +8,7 @@ var CaptureSession = require('lib/capture-session'),
     proxyquire = require('proxyquire').noCallThru(),
     _ = require('lodash'),
     QEmitter = require('qemitter'),
-    q = require('q');
+    Promise = require('bluebird');
 
 describe('state-processor/state-processor', () => {
     var sandbox = sinon.sandbox.create(),
@@ -173,13 +173,13 @@ describe('state-processor/state-processor', () => {
         });
 
         it('should restore error object inheritance', () => {
-            sandbox.stub(q, 'nfcall').returns(q.reject({name: 'NoRefImageError'}));
+            sandbox.stub(Promise, 'fromCallback').returns(Promise.reject({name: 'NoRefImageError'}));
             sandbox.stub(errorUtils, 'fromPlainObject')
                 .withArgs({name: 'NoRefImageError'})
                 .returns({restored: 'object'});
 
             return exec_()
-                .fail((err) => {
+                .catch((err) => {
                     assert.calledOnce(errorUtils.fromPlainObject);
                     assert.deepEqual(err, {restored: 'object'});
                 });

--- a/test/unit/state-processor/test-state-processor.js
+++ b/test/unit/state-processor/test-state-processor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 
 const CaptureSession = require('lib/capture-session');
 const StateProcessor = require('lib/state-processor/state-processor');
@@ -37,7 +37,7 @@ describe('state-processor/test-state-processor', () => {
             const page = {};
             const browserSession = sinon.createStubInstance(CaptureSession);
 
-            StateProcessor.prototype.exec.returns(q({}));
+            StateProcessor.prototype.exec.returns(Promise.resolve({}));
 
             return mkTestStateProc_().exec(state, browserSession, page, sinon.spy())
                 .then(() => {
@@ -48,7 +48,7 @@ describe('state-processor/test-state-processor', () => {
         it('should return result from calling base class exec method', () => {
             const result = {equal: true};
 
-            StateProcessor.prototype.exec.returns(q(result));
+            StateProcessor.prototype.exec.returns(Promise.resolve(result));
 
             return exec_()
                 .then(() => {
@@ -60,7 +60,7 @@ describe('state-processor/test-state-processor', () => {
             const result = {equal: false};
             const emit = sandbox.stub();
 
-            StateProcessor.prototype.exec.returns(q(result));
+            StateProcessor.prototype.exec.returns(Promise.resolve(result));
 
             return exec_({emit})
                 .then(() => {
@@ -72,7 +72,7 @@ describe('state-processor/test-state-processor', () => {
             const result = {equal: true};
             const emit = sandbox.stub();
 
-            StateProcessor.prototype.exec.returns(q(result));
+            StateProcessor.prototype.exec.returns(Promise.resolve(result));
 
             return exec_({emit})
                 .then(() => assert.calledWithExactly(emit, 'testResult', result));
@@ -81,7 +81,7 @@ describe('state-processor/test-state-processor', () => {
         it('should emit TEST_RESULT event without saveDiffTo func when images are equal', () => {
             const emit = sandbox.stub();
 
-            StateProcessor.prototype.exec.returns(q({equal: true}));
+            StateProcessor.prototype.exec.returns(Promise.resolve({equal: true}));
 
             return exec_({emit})
                 .then(() => assert.notProperty(emit.getCall(0).args[1], 'saveDiffTo'));

--- a/test/unit/state-processor/update-state-processor.js
+++ b/test/unit/state-processor/update-state-processor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 
 const CaptureSession = require('lib/capture-session');
 const StateProcessor = require('lib/state-processor/state-processor');
@@ -32,7 +32,7 @@ describe('state-processor/update-state-processor', () => {
             const page = {};
             const browserSession = sinon.createStubInstance(CaptureSession);
 
-            StateProcessor.prototype.exec.returns(q({}));
+            StateProcessor.prototype.exec.returns(Promise.resolve({}));
 
             return new UpdateStateProcessor().exec(state, browserSession, page, sinon.spy())
                 .then(() => {
@@ -44,7 +44,7 @@ describe('state-processor/update-state-processor', () => {
             const result = {updated: true};
             const emit = sandbox.stub();
 
-            StateProcessor.prototype.exec.returns(q(result));
+            StateProcessor.prototype.exec.returns(Promise.resolve(result));
 
             return exec_({emit})
                 .then(() => assert.calledWithExactly(emit, 'updateResult', result));
@@ -54,7 +54,7 @@ describe('state-processor/update-state-processor', () => {
             const result = {updated: false};
             const emit = sandbox.stub();
 
-            StateProcessor.prototype.exec.returns(q(result));
+            StateProcessor.prototype.exec.returns(Promise.resolve(result));
 
             return exec_({emit})
                 .then(() => assert.calledWithExactly(emit, 'updateResult', result));

--- a/test/unit/test-reader/index.js
+++ b/test/unit/test-reader/index.js
@@ -2,7 +2,7 @@
 
 const proxyquire = require('proxyquire');
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 const EventEmitter = require('events').EventEmitter;
 const utils = require('lib/utils');
 const globExtra = require('glob-extra');
@@ -33,7 +33,7 @@ describe('test-reader', () => {
 
     beforeEach(() => {
         sandbox.stub(utils, 'requireWithNoCache');
-        sandbox.stub(globExtra, 'expandPaths').returns(q([]));
+        sandbox.stub(globExtra, 'expandPaths').returns(Promise.resolve([]));
 
         readTests = proxyquire('lib/test-reader', {
             '../tests-api': testsApi
@@ -68,7 +68,7 @@ describe('test-reader', () => {
             const api = {suite: 'api'};
 
             testsApi.returns(api);
-            globExtra.expandPaths.returns(q(['some-test.js']));
+            globExtra.expandPaths.returns(Promise.resolve(['some-test.js']));
 
             return readTests_({config})
                 .then(() => assert.deepEqual(gemini, api));
@@ -77,7 +77,7 @@ describe('test-reader', () => {
         it('should rewrite global "gemini" variable for each file', () => {
             let globalGemini = [];
 
-            globExtra.expandPaths.returns(q(['/some/path/file1.js', '/some/path/file2.js']));
+            globExtra.expandPaths.returns(Promise.resolve(['/some/path/file1.js', '/some/path/file2.js']));
 
             testsApi
                 .onFirstCall().returns({suite: 'apiInstance'})
@@ -93,7 +93,7 @@ describe('test-reader', () => {
 
         it('should delete global "gemini" variable after test reading', () => {
             testsApi.returns({suite: 'api'});
-            globExtra.expandPaths.returns(q(['some-test.js']));
+            globExtra.expandPaths.returns(Promise.resolve(['some-test.js']));
             sandbox.stub(utils, 'requireWithNoCache');
 
             return readTests_({config}).then(() => assert.notProperty(global, 'gemini'));
@@ -105,7 +105,7 @@ describe('test-reader', () => {
             getBrowserIds: () => []
         };
 
-        globExtra.expandPaths.withArgs(['/root/gemini']).returns(q(['/root/gemini/file.js']));
+        globExtra.expandPaths.withArgs(['/root/gemini']).returns(Promise.resolve(['/root/gemini/file.js']));
 
         return readTests_({config})
             .then(() => assert.calledWith(utils.requireWithNoCache, '/root/gemini/file.js'));
@@ -121,7 +121,7 @@ describe('test-reader', () => {
         };
 
         globExtra.expandPaths
-            .withArgs(['some/path']).returns(q(['/some/path/file1.js', '/some/path/file2.js']));
+            .withArgs(['some/path']).returns(Promise.resolve(['/some/path/file1.js', '/some/path/file2.js']));
 
         return readTests_({config})
             .then(() => {
@@ -142,7 +142,7 @@ describe('test-reader', () => {
             }
         };
 
-        globExtra.expandPaths.withArgs(['some/path']).returns(q(['/some/path/file1.js']));
+        globExtra.expandPaths.withArgs(['some/path']).returns(Promise.resolve(['/some/path/file1.js']));
 
         return readTests_({sets: ['set1'], config})
             .then(() => assert.alwaysCalledWithExactly(utils.requireWithNoCache, '/some/path/file1.js'));
@@ -161,7 +161,7 @@ describe('test-reader', () => {
         };
 
         globExtra.expandPaths
-            .withArgs(['some/path']).returns(q(['/some/path/file1.js']));
+            .withArgs(['some/path']).returns(Promise.resolve(['/some/path/file1.js']));
 
         return readTests_({paths: ['some/path'], config})
             .then(() => {
@@ -179,8 +179,8 @@ describe('test-reader', () => {
         };
 
         globExtra.expandPaths
-            .withArgs(['some/path']).returns(q(['/some/path/file1.js']))
-            .withArgs(['some/path', 'other/path']).returns(q(['/some/path/file1.js', '/other/path/file2.js']));
+            .withArgs(['some/path']).returns(Promise.resolve(['/some/path/file1.js']))
+            .withArgs(['some/path', 'other/path']).returns(Promise.resolve(['/some/path/file1.js', '/other/path/file2.js']));
 
         return readTests_({sets: ['set1'], paths: ['some/path'], config})
             .then(() => {
@@ -215,7 +215,7 @@ describe('test-reader', () => {
             };
 
             globExtra.expandPaths
-                .withArgs(['some/path/*.js']).returns(q(['/root/some/path/file1.js']));
+                .withArgs(['some/path/*.js']).returns(Promise.resolve(['/root/some/path/file1.js']));
 
             return readTests_({paths: ['some/path/*.js'], config})
                 .then(() => {
@@ -232,7 +232,7 @@ describe('test-reader', () => {
                 }
             };
 
-            globExtra.expandPaths.withArgs(['some/path/*']).returns(q(['/root/some/path/file1.js']));
+            globExtra.expandPaths.withArgs(['some/path/*']).returns(Promise.resolve(['/root/some/path/file1.js']));
 
             return readTests_({sets: ['set1'], paths: ['some/path/*'], config})
                 .then(() => assert.calledWith(utils.requireWithNoCache, '/root/some/path/file1.js'));
@@ -247,7 +247,7 @@ describe('test-reader', () => {
                 }
             };
 
-            globExtra.expandPaths.withArgs(['other/path']).returns(q(['/root/other/path/file1.js']));
+            globExtra.expandPaths.withArgs(['other/path']).returns(Promise.resolve(['/root/other/path/file1.js']));
 
             return assert.isRejected(readTests_({paths: ['other/path'], config}), /Cannot find files/);
         });
@@ -266,7 +266,7 @@ describe('test-reader', () => {
             };
 
             globExtra.expandPaths
-                .withArgs(relativePath).returns(q([absolutePath]));
+                .withArgs(relativePath).returns(Promise.resolve([absolutePath]));
 
             return readTests_({
                 paths: [relativePath],

--- a/test/unit/test-reader/set-collection.js
+++ b/test/unit/test-reader/set-collection.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const q = require('q');
+const Promise = require('bluebird');
 const globExtra = require('glob-extra');
 const SetCollection = require('lib/test-reader/set-collection');
 const TestSet = require('lib/test-reader/test-set');
@@ -40,7 +40,7 @@ describe('set-collection', () => {
     };
 
     beforeEach(() => {
-        sandbox.stub(globExtra, 'expandPaths').returns(q([]));
+        sandbox.stub(globExtra, 'expandPaths').returns(Promise.resolve([]));
     });
 
     afterEach(() => sandbox.restore());
@@ -75,7 +75,7 @@ describe('set-collection', () => {
 
         sandbox.stub(TestSet, 'create').returns(mkSetStub());
 
-        globExtra.expandPaths.withArgs(['some/files']).returns(q(['some/files/file.js']));
+        globExtra.expandPaths.withArgs(['some/files']).returns(Promise.resolve(['some/files/file.js']));
 
         return SetCollection.create(config, mkOptsStub({sets: ['set1']}))
             .then(() => {
@@ -107,8 +107,8 @@ describe('set-collection', () => {
         });
 
         globExtra.expandPaths
-            .withArgs(['some/files']).returns(q(['some/files/file1.js']))
-            .withArgs(['other/files']).returns(q(['other/files/file2.js']));
+            .withArgs(['some/files']).returns(Promise.resolve(['some/files/file1.js']))
+            .withArgs(['other/files']).returns(Promise.resolve(['other/files/file2.js']));
 
         sandbox.stub(TestSet, 'create').returns(mkSetStub());
 
@@ -167,8 +167,8 @@ describe('set-collection', () => {
         });
 
         globExtra.expandPaths
-            .withArgs(['some/files']).returns(q(['some/files/file1.js']))
-            .withArgs(['other/files']).returns(q(['other/files/file2.js']));
+            .withArgs(['some/files']).returns(Promise.resolve(['some/files/file1.js']))
+            .withArgs(['other/files']).returns(Promise.resolve(['other/files/file2.js']));
 
         return SetCollection.create(config, mkOptsStub())
             .then((setCollection) => {

--- a/test/unit/tests-api/actions-builder.js
+++ b/test/unit/tests-api/actions-builder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const q = require('q');
+const Promise = require('bluebird');
 
 const ActionsBuilder = require('lib/tests-api/actions-builder');
 const util = require('../../util');
@@ -25,8 +25,8 @@ describe('tests-api/actions-builder', () => {
 
     describe('changeOrientation', () => {
         beforeEach(() => {
-            sandbox.stub(browser, 'getOrientation').returns(q());
-            sandbox.stub(browser, 'setOrientation').returns(q());
+            sandbox.stub(browser, 'getOrientation').returns(Promise.resolve());
+            sandbox.stub(browser, 'setOrientation').returns(Promise.resolve());
         });
 
         it('should throw in case of passed arguments', () => {
@@ -40,7 +40,7 @@ describe('tests-api/actions-builder', () => {
         });
 
         it('should change orientation from PORTRAIT to LANDSCAPE', () => {
-            browser.getOrientation.returns(q('PORTRAIT'));
+            browser.getOrientation.returns(Promise.resolve('PORTRAIT'));
             const changeOrientation = mkAction('changeOrientation', browser);
 
             return changeOrientation()
@@ -48,7 +48,7 @@ describe('tests-api/actions-builder', () => {
         });
 
         it('should change orientation from LANDSCAPE to PORTRAIT', () => {
-            browser.getOrientation.returns(q('LANDSCAPE'));
+            browser.getOrientation.returns(Promise.resolve('LANDSCAPE'));
             const changeOrientation = mkAction('changeOrientation', browser);
 
             return changeOrientation()
@@ -64,14 +64,14 @@ describe('tests-api/actions-builder', () => {
         });
 
         it('should be rejected if getting of orientation fails', () => {
-            browser.getOrientation.returns(q.reject('awesome error'));
+            browser.getOrientation.returns(Promise.reject('awesome error'));
             const changeOrientation = mkAction('changeOrientation', browser);
 
             return assert.isRejected(changeOrientation(), /awesome error/);
         });
 
         it('should be rejected if setting of orientation fails', () => {
-            browser.setOrientation.returns(q.reject('awesome error'));
+            browser.setOrientation.returns(Promise.reject('awesome error'));
             const changeOrientation = mkAction('changeOrientation', browser);
 
             return assert.isRejected(changeOrientation(), /awesome error/);
@@ -80,13 +80,13 @@ describe('tests-api/actions-builder', () => {
 
     describe('mouse actions', () => {
         beforeEach(() => {
-            sandbox.stub(browser, 'moveTo').returns(q());
-            sandbox.stub(browser, 'findElement').returns(q({}));
+            sandbox.stub(browser, 'moveTo').returns(Promise.resolve());
+            sandbox.stub(browser, 'findElement').returns(Promise.resolve({}));
         });
 
         describe('click', () => {
             beforeEach(() => {
-                sandbox.stub(browser, 'click').returns(q());
+                sandbox.stub(browser, 'click').returns(Promise.resolve());
             });
 
             it('should use left button if not specified', () => {
@@ -112,7 +112,7 @@ describe('tests-api/actions-builder', () => {
 
         describe('doubleClick', () => {
             beforeEach(() => {
-                sandbox.stub(browser, 'doubleClick').returns(q());
+                sandbox.stub(browser, 'doubleClick').returns(Promise.resolve());
             });
 
             it('should use left button if not specified', () => {
@@ -138,7 +138,7 @@ describe('tests-api/actions-builder', () => {
 
         describe('mouseDown', () => {
             beforeEach(() => {
-                sandbox.stub(browser, 'buttonDown').returns(q());
+                sandbox.stub(browser, 'buttonDown').returns(Promise.resolve());
             });
 
             it('should use left button if not specified', () => {
@@ -164,7 +164,7 @@ describe('tests-api/actions-builder', () => {
 
         describe('mouseUp', () => {
             beforeEach(() => {
-                sandbox.stub(browser, 'buttonUp').returns(q());
+                sandbox.stub(browser, 'buttonUp').returns(Promise.resolve());
             });
 
             it('should use left button if not specified', () => {

--- a/test/util.js
+++ b/test/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Browser = require('lib/browser');
+const Promise = require('bluebird');
 const State = require('lib/state');
 const Suite = require('lib/suite');
 const _ = require('lodash');
@@ -107,10 +108,22 @@ function makeSuiteTree(sceleton, rootOpts) {
     }
 }
 
+function rejectedPromise(error) {
+    if (!error) {
+        error = new Error('Rejected');
+    } else if (typeof error === 'string') {
+        error = new Error(error);
+    }
+    const promise = Promise.reject(error);
+    promise.catch(() => {});
+    return promise;
+}
+
 module.exports = {
     makeBrowser,
     browserWithId,
     makeStateStub,
     makeSuiteStub,
-    makeSuiteTree
+    makeSuiteTree,
+    rejectedPromise
 };


### PR DESCRIPTION
For the most parts, conversation done half-automatically
(https://gist.github.com/SevInf/007cbce5c5ad6898dc28c279998445ac)

Code using Q.defer() required manual updating. Please, pay attention
to LimitedPool class.

Internally, only bluebirds promises are used.
For outside world, at least for 4.x, blueberd promosies adapted to
Q-like interface using bluebird-q library.

Since bluebird warns about unhandled rejections by default, few tests
required changes. For creating rejected promises
test/util:rejectedPromise should now be used to suppress the warning.

q-promise-utils and q-io are still there, their replacement is the next
step.

@j0tunn @sipayRT @eGavr @DudaGod 