### PR TITLE
START_RUNNER and END_RUNNER events should be emitted through emitAndWait

### DIFF
--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -32,7 +32,7 @@ module.exports = class TestsRunner extends Runner {
         const suites = suiteCollection.allSuites();
 
         return q.fcall(() => {
-            this.emit(Events.START_RUNNER, this);
+            this.emitAndWait(Events.START_RUNNER, this);
             this.emit(Events.BEGIN, {
                 config: this.config,
                 totalStates: _.reduce(suites, (result, suite) => {
@@ -46,7 +46,7 @@ module.exports = class TestsRunner extends Runner {
         .then(() => this.coverage && this.coverage.processStats())
         .finally(() => {
             this.emit(Events.END);
-            this.emit(Events.END_RUNNER, this);
+            this.emitAndWait(Events.END_RUNNER, this);
         });
     }
 

--- a/test/unit/runner/index.js
+++ b/test/unit/runner/index.js
@@ -107,6 +107,16 @@ describe('runner', () => {
                 .then(() => assert.calledWith(onStartRunner, runner));
         });
 
+        it('should wait for resolving a listener when `START_RUNNER` event was emitted', () => {
+            const onStartRunner = sandbox.spy().named('onStartRunner');
+            runner.on(Events.START_RUNNER, onStartRunner);
+
+            sandbox.spy(Runner.prototype, 'emitAndWait');
+
+            return run_()
+                .then(() => assert.calledWith(runner.emitAndWait, Events.START_RUNNER));
+        });
+
         it('should launch only browsers specified in testBrowsers', () => {
             runner.config.getBrowserIds.returns(['browser1', 'browser2']);
             runner.setTestBrowsers(['browser1']);
@@ -147,6 +157,16 @@ describe('runner', () => {
 
             return run_()
                 .then(() => assert.calledWith(onEndRunner, runner));
+        });
+
+        it('should wait for resolving a listener when `END_RUNNER` event was emitted', () => {
+            const onStartRunner = sandbox.spy().named('onStartRunner');
+            runner.on(Events.END_RUNNER, onStartRunner);
+
+            sandbox.spy(Runner.prototype, 'emitAndWait');
+
+            return run_()
+                .then(() => assert.calledWith(runner.emitAndWait, Events.END_RUNNER));
         });
 
         it('should emit events in correct order', () => {


### PR DESCRIPTION
For now START_RUNNER and END_RUNNER events are emitted through `emit` and we didn't wait for the results. The problem is that on these events executed heavy initialization and if it has errors, we don't see it. These events should be emitted by `emitAndWait`.