### PR TITLE
Move plugin loading back to constructor

### DIFF
--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -34,6 +34,7 @@ module.exports = class Gemini extends PassthroughEmitter {
         this.SuiteCollection = SuiteCollection;
 
         setupLog(this.config.system.debug);
+        this._loadPlugins();
     }
 
     _run(stateProcessor, paths, options) {
@@ -55,7 +56,6 @@ module.exports = class Gemini extends PassthroughEmitter {
         const browsers = options.browsers || envBrowsers;
 
         this._passThroughEvents(runner);
-        this._loadPlugins();
 
         if (browsers) {
             this.checkUnknownBrowsers(browsers);

--- a/test/unit/gemini.js
+++ b/test/unit/gemini.js
@@ -115,6 +115,14 @@ describe('gemini', () => {
         });
     });
 
+    it('should load plugins before reading tests', () => {
+        sandbox.stub(temp, 'init');
+        return runGeminiTest()
+            .then(() => {
+                assert.callOrder(plugins.load, testReaderStub);
+            });
+    });
+
     describe('readTests', () => {
         const readTests_ = (rootSuite, options) => {
             gemini = initGemini({rootSuite});


### PR DESCRIPTION
Restores pre-4.11 behavior.

Calling it in `run` (after test files have been read) makes it impossible for plugins to affect how files are read. For example, [gemini-babel](https://github.com/researchgate/gemini-babel) plugin stops working entirely.