### PR TITLE
Cast result of all wd method to Bluebird promises

### DIFF
--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const Promise = require('bluebird');
-const wd = require('wd');
+const wd = require('./wd-bluebird');
 
 const Camera = require('./camera');
 
@@ -45,6 +44,6 @@ module.exports = class Browser {
     }
 
     _configureHttp(timeout) {
-        return Promise.resolve(this._wd.configureHttp({retries: 'never', timeout}));
+        return this._wd.configureHttp({retries: 'never', timeout});
     }
 };

--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -74,16 +74,16 @@ module.exports = class NewBrowser extends Browser {
     }
 
     _applyWdMethodInContext(method, context, args) {
-        return Promise.resolve(this._wd.currentContext())
+        return this._wd.currentContext()
             .then((originalContext) => {
-                return Promise.resolve(this._wd.context(context))
+                return this._wd.context(context)
                     .then(() => this._applyWdMethod(method, args))
                     .finally(() => this._wd.context(originalContext));
             });
     }
 
     _applyWdMethod(method, args) {
-        return Promise.resolve(this._wd[method].apply(this._wd, args));
+        return this._wd[method].apply(this._wd, args);
     }
 
     launch(calibrator) {
@@ -151,7 +151,7 @@ module.exports = class NewBrowser extends Browser {
             return;
         }
 
-        return Promise.resolve(this._wd.setWindowSize(size.width, size.height))
+        return this._wd.setWindowSize(size.width, size.height)
             .catch((e) => {
                 // Its the only reliable way to detect not supported operation
                 // in legacy operadriver.
@@ -171,7 +171,7 @@ module.exports = class NewBrowser extends Browser {
     _buildPolyfills() {
         //polyfills are needed for older browsers, namely, IE8
 
-        return Promise.resolve(this._wd.eval('navigator.userAgent'))
+        return this._wd.eval('navigator.userAgent')
             .then((ua) => {
                 return polyfillService.getPolyfillString({
                     uaString: ua,
@@ -198,7 +198,7 @@ module.exports = class NewBrowser extends Browser {
             resetZoom: true
         });
 
-        return Promise.resolve(this._wd.get(url))
+        return this._wd.get(url)
             .then((url) => {
                 return params.resetZoom
                     ? this._clientBridge.call('resetZoom').thenReturn(url)
@@ -207,11 +207,11 @@ module.exports = class NewBrowser extends Browser {
     }
 
     injectScript(script) {
-        return Promise.resolve(this._wd.execute(script));
+        return this._wd.execute(script);
     }
 
     evalScript(script) {
-        return Promise.resolve(this._wd.eval(script));
+        return this._wd.eval(script);
     }
 
     buildScripts() {
@@ -291,7 +291,7 @@ module.exports = class NewBrowser extends Browser {
     }
 
     _maximize() {
-        return Promise.resolve(this._wd.windowHandle())
+        return this._wd.windowHandle()
             .then((handle) => this._wd.maximize(handle));
     }
 
@@ -300,7 +300,7 @@ module.exports = class NewBrowser extends Browser {
     }
 
     _findElementWd(selector) {
-        return Promise.resolve(this._wd.elementByCssSelector(selector))
+        return this._wd.elementByCssSelector(selector)
             .catch((error) => {
                 if (error.status === WdErrors.ELEMENT_NOT_FOUND) {
                     error.selector = selector;

--- a/lib/browser/wd-bluebird.js
+++ b/lib/browser/wd-bluebird.js
@@ -1,0 +1,44 @@
+'use strict';
+const wd = require('wd');
+const _ = require('lodash');
+const Promise = require('bluebird');
+const EventEmitter = require('events').EventEmitter;
+
+function isPromised(methodName) {
+    if (Object.prototype[methodName]) {
+        return false;
+    }
+
+    if (EventEmitter.prototype[methodName]) {
+        return false;
+    }
+
+    return true;
+}
+
+function wrap(propertyName, original) {
+    if (_.isFunction(original[propertyName])) {
+        if (isPromised(propertyName)) {
+            return wrapPromised(propertyName, original);
+        }
+
+        return original[propertyName].bind(original);
+    }
+    return original[propertyName];
+}
+
+function wrapPromised(methodName, original) {
+    return function() {
+        return Promise.resolve(original[methodName].apply(original, arguments));
+    };
+}
+
+exports.promiseRemote = (gridUrl) => {
+    const remote = wd.promiseRemote(gridUrl);
+    const bluebirdRemote = {};
+
+    for (let prop in remote) {
+        bluebirdRemote[prop] = wrap(prop, remote);
+    }
+    return bluebirdRemote;
+};

--- a/test/unit/browser/wd-bluebird.js
+++ b/test/unit/browser/wd-bluebird.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const Promise = require('bluebird');
+const q = require('bluebird-q');
+const proxyquire = require('proxyquire');
+
+describe('wd-bluebird', () => {
+    const sandbox = sinon.sandbox.create();
+    let original, wrapped;
+
+    beforeEach(() => {
+        original = {
+            promiseMethod: () => q('result'),
+            emit() {},
+            property: 'value'
+        };
+
+        const wd = proxyquire('lib/browser/wd-bluebird', {
+            wd: {
+                promiseRemote: () => original
+            }
+        });
+
+        wrapped = wd.promiseRemote();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('should cast original promise to Bluebird', () => {
+        assert.instanceOf(
+            wrapped.promiseMethod(),
+            Promise
+        );
+    });
+
+    it('should resolve to original value', () => {
+        return assert.eventually.equal(
+            wrapped.promiseMethod(),
+            original.promiseMethod()
+        );
+    });
+
+    it('should forward all arguments to original method', () => {
+        const arg = 'arg';
+        sandbox.spy(original, 'promiseMethod');
+
+        wrapped.promiseMethod(arg);
+
+        assert.calledWith(original.promiseMethod, arg);
+    });
+
+    it('should copy properties as is', () => {
+        assert.equal(wrapped.property, original.property);
+    });
+
+    it('should not cast event emitter methods results', () => {
+        assert.isUndefined(
+            wrapped.emit('event')
+        );
+    });
+
+    it('should not cast Object.prototype methods results', () => {
+        assert.isString(
+            wrapped.toString()
+        );
+    });
+});


### PR DESCRIPTION
Introduce small wd-bluebird module, which just wraps existing
wd methods and cast the result to Blubird promise.

/cc @sipayRT @j0tunn @DudaGod 