### PR TITLE
Actually wait for START_RUNNER event to complete

### DIFF
--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -46,7 +46,7 @@ module.exports = class TestsRunner extends Runner {
             .then(() => this.coverage && this.coverage.processStats())
             .finally(() => {
                 this.emit(Events.END);
-                this.emitAndWait(Events.END_RUNNER, this);
+                return this.emitAndWait(Events.END_RUNNER, this);
             });
     }
 

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -31,23 +31,23 @@ module.exports = class TestsRunner extends Runner {
     run(suiteCollection) {
         const suites = suiteCollection.allSuites();
 
-        return Promise.try(() => {
-            this.emitAndWait(Events.START_RUNNER, this);
-            this.emit(Events.BEGIN, {
-                config: this.config,
-                totalStates: _.reduce(suites, (result, suite) => {
-                    return result + suite.states.length;
-                }, 0),
-                browserIds: this.config.getBrowserIds()
+        return Promise.resolve(this.emitAndWait(Events.START_RUNNER, this))
+            .then(() => {
+                this.emit(Events.BEGIN, {
+                    config: this.config,
+                    totalStates: _.reduce(suites, (result, suite) => {
+                        return result + suite.states.length;
+                    }, 0),
+                    browserIds: this.config.getBrowserIds()
+                });
+            })
+            .then(() => this._prepare())
+            .then(() => this._runTestSession(suiteCollection))
+            .then(() => this.coverage && this.coverage.processStats())
+            .finally(() => {
+                this.emit(Events.END);
+                this.emitAndWait(Events.END_RUNNER, this);
             });
-        })
-        .then(() => this._prepare())
-        .then(() => this._runTestSession(suiteCollection))
-        .then(() => this.coverage && this.coverage.processStats())
-        .finally(() => {
-            this.emit(Events.END);
-            this.emitAndWait(Events.END_RUNNER, this);
-        });
     }
 
     _runTestSession(suiteCollection) {

--- a/test/unit/runner/index.js
+++ b/test/unit/runner/index.js
@@ -52,9 +52,7 @@ describe('runner', () => {
 
         it('should wait until all `START_RUNNER` handlers have finished', () => {
             const onStartRunner = sandbox.spy().named('onStartRunner');
-            const onStartRannerWithDelay = () => {
-                return Promise.delay(50).then(onStartRunner);
-            };
+            const onStartRannerWithDelay = () => Promise.delay(50).then(onStartRunner);
             const onBegin = sandbox.spy().named('onBegin');
 
             runner.on(Events.START_RUNNER, onStartRannerWithDelay);

--- a/test/unit/runner/index.js
+++ b/test/unit/runner/index.js
@@ -50,6 +50,22 @@ describe('runner', () => {
                 .then(() => assert.calledOnce(onBegin));
         });
 
+        it('should wait until all `START_RUNNER` handlers have finished', () => {
+            const onStartRunner = sandbox.spy().named('onStartRunner');
+            const onStartRannerWithDelay = () => {
+                return Promise.delay(50).then(onStartRunner);
+            };
+            const onBegin = sandbox.spy().named('onBegin');
+
+            runner.on(Events.START_RUNNER, onStartRannerWithDelay);
+            runner.on(Events.BEGIN, onBegin);
+
+            return run_()
+                .then(() => {
+                    assert.callOrder(onStartRunner, onBegin);
+                });
+        });
+
         it('should pass total number of states when emitting `BEGIN`', () => {
             const suites = [
                 {states: []},


### PR DESCRIPTION
Current code does not actually waits for the event to complete.
It becomes noticeable when plugins tries to run a long job (longer then
starting up selenium).

/cc @j0tunn @sipayRT 