### PR TITLE
Don't fail if cli masks does not contain any file or sets are empty.

### DIFF
--- a/lib/test-reader/set-collection.js
+++ b/lib/test-reader/set-collection.js
@@ -73,7 +73,7 @@ module.exports = class SetCollection {
     }
 
     static _isAllFilesMasks(sets) {
-        return _.every(sets, (set) => globExtra.isMasks(set.files));
+        return _.every(sets, (set) => _.every(set.files, globExtra.isMask));
     }
 
     constructor(sets, opts) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-extra": "^0.30.0",
     "gemini-configparser": "^0.1.1",
     "gemini-coverage": "^1.0.0",
-    "glob-extra": "^1.3.0",
+    "glob-extra": "^1.3.2",
     "handlebars": "^4.0.5",
     "inherit": "~2.2.1",
     "install": "^0.6.1",

--- a/test/unit/test-reader/index.js
+++ b/test/unit/test-reader/index.js
@@ -198,7 +198,10 @@ describe('test-reader', () => {
             }
         };
 
-        return assert.isRejected(readTests_({paths: ['other/path'], config}), /Cannot find files/);
+        globExtra.expandPaths.withArgs(['some/path']).returns(Promise.resolve(['/some/path/file1.js']));
+        globExtra.expandPaths.withArgs(['other/path']).returns(Promise.resolve(['/other/path/file1.js']));
+
+        return assert.isRejected(readTests_({paths: ['other/path'], config}), 'Cannot find files by masks in sets');
     });
 
     describe('files of sets are specified as masks', () => {
@@ -247,9 +250,10 @@ describe('test-reader', () => {
                 }
             };
 
-            globExtra.expandPaths.withArgs(['other/path']).returns(Promise.resolve(['/root/other/path/file1.js']));
+            globExtra.expandPaths.withArgs(['some/path']).returns(Promise.resolve(['/some/path/file1.js']));
+            globExtra.expandPaths.withArgs(['other/path']).returns(Promise.resolve(['/other/path/file1.js']));
 
-            return assert.isRejected(readTests_({paths: ['other/path'], config}), /Cannot find files/);
+            return assert.isRejected(readTests_({paths: ['other/path'], config}), 'Cannot find files by masks in sets');
         });
     });
 


### PR DESCRIPTION
Currently if all sets does not contain any files or client pass mask that does not expand to any file gemini will fail. I think in this case be better if it just continue execution without any file. Also in this PR I found some tests issues and fix them.