### PR TITLE
Fix css coverage issue if using sass variables

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -194,7 +194,7 @@ module.exports = inherit({
             // variables and a buggy implementation of sourcemaps in both ruby sass
             // as well as lib sass the rule end would map to the end of the variable
             // declaration instead of the correct end of the css rule
-            sourceEnd = getPosition(rule.declarations[rule.declarations.length -1].position.start, opts.url, opts.map),
+            sourceEnd = getPosition(rule.declarations[rule.declarations.length - 1].position.start, opts.url, opts.map),
             // Synchronous realpath() is used because of original method is totally synchronous and recursive,
             // while the order of recursive calls is important. Making the code being asynchronous won't make
             // much benefit considering only one async call can be executed to guarantee the calling order.

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -189,6 +189,11 @@ module.exports = inherit({
         }.bind(this), coverageLevel.NONE);
 
         var sourceStart = getPosition(rule.position.start, opts.url, opts.map),
+            // We're using the start of the last declaration here instead of the
+            // rule.position.end, because due for example to the use of sass
+            // variables and a buggy implementation of sourcemaps in both ruby sass
+            // as well as lib sass the rule end would map to the end of the variable
+            // declaration instead of the correct end of the css rule
             sourceEnd = getPosition(rule.declarations[rule.declarations.length -1].position.start, opts.url, opts.map),
             // Synchronous realpath() is used because of original method is totally synchronous and recursive,
             // while the order of recursive calls is important. Making the code being asynchronous won't make

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -189,7 +189,7 @@ module.exports = inherit({
         }.bind(this), coverageLevel.NONE);
 
         var sourceStart = getPosition(rule.position.start, opts.url, opts.map),
-            sourceEnd = getPosition(rule.position.end, opts.url, opts.map),
+            sourceEnd = getPosition(rule.declarations[rule.declarations.length -1].position.start, opts.url, opts.map),
             // Synchronous realpath() is used because of original method is totally synchronous and recursive,
             // while the order of recursive calls is important. Making the code being asynchronous won't make
             // much benefit considering only one async call can be executed to guarantee the calling order.


### PR DESCRIPTION
## Problem

When a sass is used with the following construct

```scss
$variable: green;

.selector {
  color: $variable;
}
```

The parsed css & source map will map the end of rule .selector to the end of the variable declaration instead of the last line.
This is due to buggy source maps in both node-sass & ruby-sass.
A colleague of mine is already fixing lib-sass, which is the c++ sass compiler which is used by node-sass.

## Solution
Since css coverage is only interested in a line/block level coverage the start of the last declaration within the rule will be mapped correctly by the source map.
This should also have no effects on just minified css and other pre-compilers like less