### PR TITLE
html-reporter: don't store reference image when it is equal with current

### DIFF
--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -1,17 +1,15 @@
 'use strict';
 
-var path = require('path'),
+const path = require('path');
+const chalk = require('chalk');
+const fs = require('fs-extra');
+const Promise = require('bluebird');
 
-    Promise = require('bluebird'),
-    fs = require('fs-extra'),
-
-    view = require('./view'),
-    ViewModel = require('./view-model'),
-    lib = require('./lib'),
-    chalk = require('chalk'),
-    logger = require('../../utils').logger,
-
-    Events = require('../../constants/events');
+const lib = require('./lib');
+const view = require('./view');
+const ViewModel = require('./view-model');
+const logger = require('../../utils').logger;
+const Events = require('../../constants/events');
 
 /**
  * @param {String} srcPath
@@ -20,7 +18,7 @@ var path = require('path'),
  */
 function copyImage(srcPath, destPath) {
     return makeDirFor(destPath)
-        .then(fs.copyAsync.bind(fs, srcPath, destPath));
+        .then(() => fs.copyAsync(srcPath, destPath));
 }
 
 /**
@@ -30,7 +28,7 @@ function copyImage(srcPath, destPath) {
  */
 function saveDiff(result, destPath) {
     return makeDirFor(destPath)
-        .then(result.saveDiffTo.bind(result, destPath));
+        .then(() => result.saveDiffTo(destPath));
 }
 
 /**
@@ -46,12 +44,8 @@ function prepareViewData(runner) {
 
         runner.on(Events.SKIP_STATE, model.addSkipped.bind(model));
 
-        runner.on(Events.TEST_RESULT, function(r) {
-            if (r.equal) {
-                model.addSuccess(r);
-            } else {
-                model.addFail(r);
-            }
+        runner.on(Events.TEST_RESULT, (result) => {
+            result.equal ? model.addSuccess(result) : model.addFail(result);
         });
 
         runner.on(Events.RETRY, model.addRetry.bind(model));
@@ -59,7 +53,7 @@ function prepareViewData(runner) {
         runner.on(Events.ERROR, model.addError.bind(model));
         runner.on(Events.WARNING, model.addWarning.bind(model));
 
-        runner.on(Events.END, function() {
+        runner.on(Events.END, () => {
             resolve(model.getResult());
         });
     });
@@ -77,11 +71,18 @@ function logPathToHtmlReport() {
 
 function prepareImages(runner) {
     function handleTestResultEvent_(testResult) {
-        return Promise.all([
-            copyImage(testResult.currentPath, lib.currentAbsolutePath(testResult)),
-            copyImage(testResult.referencePath, lib.referenceAbsolutePath(testResult)),
-            testResult.equal || saveDiff(testResult, lib.diffAbsolutePath(testResult))
-        ]);
+        let actions = [
+            copyImage(testResult.currentPath, lib.currentAbsolutePath(testResult))
+        ];
+
+        if (!testResult.equal) {
+            actions.push(
+                copyImage(testResult.referencePath, lib.referenceAbsolutePath(testResult)),
+                saveDiff(testResult, lib.diffAbsolutePath(testResult))
+            );
+        }
+
+        return Promise.all(actions);
     }
 
     function handleErrorEvent_(testResult) {
@@ -93,20 +94,18 @@ function prepareImages(runner) {
     return new Promise((resolve, reject) => {
         let queue = Promise.resolve(true);
 
-        runner.on(Events.WARNING, function(testResult) {
-            queue = queue.then(function() {
+        runner.on(Events.WARNING, (testResult) => {
+            queue = queue.then(() => {
                 return copyImage(testResult.currentPath, lib.currentAbsolutePath(testResult));
             });
         });
 
-        runner.on(Events.ERROR, function(testResult) {
-            queue = queue.then(function() {
-                return handleErrorEvent_(testResult);
-            });
+        runner.on(Events.ERROR, (testResult) => {
+            queue = queue.then(() => handleErrorEvent_(testResult));
         });
 
-        runner.on(Events.RETRY, function(testResult) {
-            queue = queue.then(function() {
+        runner.on(Events.RETRY, (testResult) => {
+            queue = queue.then(() => {
                 return testResult.hasOwnProperty('equal')
                     ? handleTestResultEvent_(testResult)
                     : handleErrorEvent_(testResult);
@@ -114,26 +113,21 @@ function prepareImages(runner) {
         });
 
         runner.on(Events.TEST_RESULT, function(testResult) {
-            queue = queue.then(function() {
-                return handleTestResultEvent_(testResult);
-            });
+            queue = queue.then(() => handleTestResultEvent_(testResult));
         });
 
-        runner.on(Events.END, function() {
-            logPathToHtmlReport();
-
+        runner.on(Events.END, () => {
             queue.then(resolve, reject);
         });
     });
 }
 
-module.exports = function htmlReporter(tester) {
-    Promise.all([
-        prepareViewData(tester),
-        prepareImages(tester)
-    ])
+module.exports = function htmlReporter(runner) {
+    const generateReportPromise = Promise.all([prepareViewData(runner), prepareImages(runner)])
         .spread(view.createHtml)
         .then(view.save)
-        .catch(logError)
-        .done();
+        .then(logPathToHtmlReport)
+        .catch(logError);
+
+    runner.on(Events.END_RUNNER, () => generateReportPromise.thenReturn());
 };

--- a/test/unit/reporters/html/html.test.js
+++ b/test/unit/reporters/html/html.test.js
@@ -1,22 +1,43 @@
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
+const _ = require('lodash');
+const fs = require('fs-extra');
+const Promise = require('bluebird');
+const QEmitter = require('qemitter');
 const HtmlReporter = require('lib/reporters/html/index.js');
 const Events = require('lib/constants/events');
 const Handlebars = require('handlebars');
 const logger = require('lib/utils').logger;
 const chalk = require('chalk');
 const path = require('path');
+const lib = require('lib/reporters/html/lib');
 const view = require('lib/reporters/html/view');
 
 describe('HTML Reporter', () => {
     const sandbox = sinon.sandbox.create();
     let emitter;
 
+    function mkStubResult_(options) {
+        return _.defaultsDeep(options, {
+            state: {name: 'name-default'},
+            browserId: 'browserId-default',
+            suite: {
+                path: ['suite/path-default'],
+                metaInfo: {sessionId: 'sessionId-default'}
+            },
+            currentPath: 'current/path-default',
+            referencePath: 'reference/path-default',
+            equal: false
+        });
+    }
+
     beforeEach(() => {
         sandbox.stub(view, 'save');
+        sandbox.stub(logger, 'log');
+        sandbox.stub(fs, 'copyAsync').returns(Promise.resolve());
+        sandbox.stub(fs, 'mkdirsAsync').returns(Promise.resolve());
 
-        emitter = new EventEmitter();
+        emitter = new QEmitter();
 
         // calling constructor for its side effect
         new HtmlReporter(emitter); // eslint-disable-line no-new
@@ -25,12 +46,12 @@ describe('HTML Reporter', () => {
     afterEach(() => sandbox.restore());
 
     it('should log correct path to html report', () => {
-        sandbox.stub(logger, 'log');
-
         emitter.emit(Events.END);
 
-        const reportPath = `file://${path.resolve('gemini-report/index.html')}`;
-        assert.calledWith(logger.log, `Your HTML report is here: ${chalk.yellow(reportPath)}`);
+        return emitter.emitAndWait(Events.END_RUNNER).then(() => {
+            const reportPath = `file://${path.resolve('gemini-report/index.html')}`;
+            assert.calledWith(logger.log, `Your HTML report is here: ${chalk.yellow(reportPath)}`);
+        });
     });
 
     it('should escape special chars in urls', () => {
@@ -41,5 +62,58 @@ describe('HTML Reporter', () => {
         const render = Handlebars.compile('{{image "actual"}}');
 
         assert.equal(render(data), '<img data-src="images/fake/long%2Bpath/fakeName/fakeId~current.png">');
+    });
+
+    it('should save only current when screenshots are equal', () => {
+        sandbox.stub(lib, 'currentAbsolutePath').returns('absolute/current/path');
+
+        emitter.emit(Events.TEST_RESULT, mkStubResult_({
+            currentPath: 'current/path',
+            equal: true
+        }));
+
+        emitter.emit(Events.END);
+
+        return emitter.emitAndWait(Events.END_RUNNER).then(() => {
+            assert.calledOnce(fs.copyAsync);
+            assert.calledWith(fs.copyAsync, 'current/path', 'absolute/current/path');
+        });
+    });
+
+    describe('when screenshots are not equal', () => {
+        function emitResult_(options) {
+            emitter.emit(Events.TEST_RESULT, mkStubResult_(options));
+            emitter.emit(Events.END);
+            return emitter.emitAndWait(Events.END_RUNNER);
+        }
+
+        it('should save current image', () => {
+            sandbox.stub(lib, 'currentAbsolutePath').returns('/absolute/report/current/path');
+
+            return emitResult_({currentPath: 'current/path'})
+                .then(() => {
+                    assert.calledWith(fs.copyAsync, 'current/path', '/absolute/report/current/path');
+                });
+        });
+
+        it('should save reference image', () => {
+            sandbox.stub(lib, 'referenceAbsolutePath').returns('/absolute/report/reference/path');
+
+            return emitResult_({referencePath: 'reference/path'})
+                .then(() => {
+                    assert.calledWith(fs.copyAsync, 'reference/path', '/absolute/report/reference/path');
+                });
+        });
+
+        it('should save diff image', () => {
+            const saveDiffTo = sandbox.stub();
+
+            sandbox.stub(lib, 'diffAbsolutePath').returns('/absolute/report/diff/path');
+
+            return emitResult_({saveDiffTo})
+                .then(() => {
+                    assert.calledWith(saveDiffTo, '/absolute/report/diff/path');
+                });
+        });
     });
 });


### PR DESCRIPTION
When html reporter receives test state result with equal current and reference screenshots it stores both, but when it generates report markup reference image is not used for successful states. It leads to wasteful hard space usage and must be stopped.
