### PR TITLE
chore: bump wd to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "temp": "~0.8.0",
     "uglify-js": "^2.7.3",
     "uglifyify": "^3.0.1",
-    "wd": "^0.4.0",
+    "wd": "^1.0.0",
     "worker-farm": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
wd 0.4 has some badly outdated transitive dependencies.
