### PR TITLE
Use JSON.parse for plugins values from cli/env

### DIFF
--- a/lib/config/util.js
+++ b/lib/config/util.js
@@ -48,6 +48,18 @@ function parseBoolean(value) {
     }
 }
 
+function parsePrimitive(str) {
+    let value;
+
+    try {
+        value = JSON.parse(str);
+    } catch (error) {
+        // do nothing
+    }
+
+    return value;
+}
+
 function positiveIntegerOption(defaultValue) {
     return option({
         parseEnv: Number,
@@ -70,7 +82,10 @@ function positiveIntegerOption(defaultValue) {
 }
 
 function anyObject() {
-    return map(option({}));
+    return map(option({
+        parseEnv: parsePrimitive,
+        parseCli: parsePrimitive
+    }));
 }
 
 exports.is = is;

--- a/lib/config/util.js
+++ b/lib/config/util.js
@@ -49,15 +49,11 @@ function parseBoolean(value) {
 }
 
 function parsePrimitive(str) {
-    let value;
-
     try {
-        value = JSON.parse(str);
+        return JSON.parse(str);
     } catch (error) {
-        // do nothing
+        throw new GeminiError('a value must be a primitive type');
     }
-
-    return value;
 }
 
 function positiveIntegerOption(defaultValue) {

--- a/test/unit/config-options/config-options.test.js
+++ b/test/unit/config-options/config-options.test.js
@@ -8,7 +8,10 @@ var Config = require('lib/config'),
 describe('config', function() {
     var VALID_OPTIONS = {
         system: {
-            projectRoot: '/some/path'
+            projectRoot: '/some/path',
+            plugins: {
+                plugin: {}
+            }
         },
         rootUrl: 'http://example.com/root',
         gridUrl: 'http://example.com/root',
@@ -221,6 +224,38 @@ describe('config', function() {
                 property: name,
                 value: 'false',
                 expected: false
+            });
+        });
+    }
+
+    function testObjectOption(name) {
+        it('should parse any of primitive type from environment', () => {
+            ['string', 1.0, 1, false, null, [], {a: 1}].forEach((expected) => {
+                const value = JSON.stringify(expected);
+                assertParsesEnv({property: name, value, expected});
+            });
+        });
+
+        it('should not throws if value from environment is not valid', () => {
+            ['{a:1}', '{', ']', '\'string\'', '\n'].forEach((value) => {
+                assert.doesNotThrow(() => {
+                    assertParsesEnv({property: name, value});
+                });
+            });
+        });
+
+        it('should parse any of primitive type from cli', () => {
+            ['string', 1.0, 1, false, null, [], {a: 1}].forEach((expected) => {
+                const value = JSON.stringify(expected);
+                assertParsesCli({property: name, value, expected});
+            });
+        });
+
+        it('should not throws if value from cli is not valid', () => {
+            ['{a:1}', '{', ']', '\'string\'', '\n'].forEach((value) => {
+                assert.doesNotThrow(() => {
+                    assertParsesCli({property: name, value});
+                });
             });
         });
     }
@@ -438,6 +473,10 @@ describe('config', function() {
                     ]);
                 });
             });
+        });
+
+        describe.only('plugins', () => {
+            testObjectOption('system.plugins.plugin');
         });
     });
 

--- a/test/unit/config-options/config-options.test.js
+++ b/test/unit/config-options/config-options.test.js
@@ -236,11 +236,11 @@ describe('config', function() {
             });
         });
 
-        it('should not throws if value from environment is not valid', () => {
+        it('should throw if value from environment is not valid', () => {
             ['{a:1}', '{', ']', '\'string\'', '\n'].forEach((value) => {
-                assert.doesNotThrow(() => {
+                assert.throw(() => {
                     assertParsesEnv({property: name, value});
-                });
+                }, GeminiError);
             });
         });
 
@@ -251,11 +251,11 @@ describe('config', function() {
             });
         });
 
-        it('should not throws if value from cli is not valid', () => {
+        it('should throw if value from cli is not valid', () => {
             ['{a:1}', '{', ']', '\'string\'', '\n'].forEach((value) => {
-                assert.doesNotThrow(() => {
+                assert.throw(() => {
                     assertParsesCli({property: name, value});
-                });
+                }, GeminiError);
             });
         });
     }
@@ -475,7 +475,7 @@ describe('config', function() {
             });
         });
 
-        describe.only('plugins', () => {
+        describe('plugins', () => {
             testObjectOption('system.plugins.plugin');
         });
     });


### PR DESCRIPTION
Currently if you set one of values in system.plugins through environment variable using <name>=false, you got string type rather than bool. I propose to use JSON.parse to preprocess values received from environment. Maybe in future be cool to add support for setting values for plugin parameters.