### PR TITLE
refactor: remove legacy which provides handling of errors from suites

### DIFF
--- a/lib/runner/suite-runner/insistent-suite-runner.js
+++ b/lib/runner/suite-runner/insistent-suite-runner.js
@@ -4,9 +4,7 @@ const SuiteRunner = require('./suite-runner');
 const RegularSuiteRunner = require('./regular-suite-runner');
 const SuiteCollection = require('../../suite-collection');
 const Events = require('../../constants/events');
-const CancelledError = require('../../errors/cancelled-error');
 const NoRefImageError = require('../../errors/no-ref-image-error');
-const Promise = require('bluebird');
 const _ = require('lodash');
 
 module.exports = class InsistentSuiteRunner extends SuiteRunner {
@@ -28,10 +26,9 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
 
     _doRun(stateProcessor) {
         this._suiteRunner = this._initSuiteRunner();
-        this._shouldRetry = false;
+        this._statesToRetry = [];
 
         return this._suiteRunner.run(stateProcessor)
-            .catch((e) => this._handleError(e) || Promise.reject(e))
             .then(() => this._retry(stateProcessor));
     }
 
@@ -63,22 +60,8 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
         });
     }
 
-    _handleError(e) {
-        if (e instanceof CancelledError) {
-            this._shouldRetry = false;
-            return true;
-        }
-
-        if (this._submitForRetry(e)) {
-            return true;
-        }
-
-        this._emit(Events.ERROR, e);
-        return false;
-    }
-
     _retry(stateProcessor) {
-        if (!this._shouldRetry) {
+        if (_.isEmpty(this._statesToRetry)) {
             return;
         }
 
@@ -87,13 +70,13 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
     }
 
     _disablePassedStates(suite) {
-        if (!_.isArray(this._shouldRetry)) {
+        if (_.isEmpty(this._statesToRetry)) {
             return;
         }
 
         const collection = new SuiteCollection([suite]).disableAll();
         const browser = this._browserAgent.browserId;
-        this._shouldRetry.forEach((state) => collection.enable(suite, {state, browser}));
+        this._statesToRetry.forEach((state) => collection.enable(suite, {state, browser}));
     }
 
     _submitForRetry(e) {
@@ -102,9 +85,7 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
             return false;
         }
 
-        this._shouldRetry = this._shouldRetry === true
-            || !e.state
-            || (this._shouldRetry || []).concat(e.state.name);
+        this._statesToRetry = this._statesToRetry.concat(e.state.name);
 
         this._emit(Events.RETRY, _.extend(e, {attempt: this._retriesPerformed, retriesLeft}));
         return true;


### PR DESCRIPTION
cc @j0tunn @sipayRT 

Видимо все это тянется со времен, когда из `suite`-раннеров мог лететь `reject`. Сейчас же все ошибки из `suite`-раннеров обрабатываются и прокидываются в стейты.

Пулл-реквест нужен для закрытия задачи про корректную обработку сигналов (`SIGTERM`, `SIGINT` и т д).