### PR TITLE
feat(config): add "ignoreAntialiasing" option

### DIFF
--- a/lib/image/index.js
+++ b/lib/image/index.js
@@ -78,16 +78,7 @@ class Image {
 
     static compare(path1, path2, opts) {
         opts = opts || {};
-        const compareOptions = {
-            ignoreCaret: opts.canHaveCaret,
-            pixelRatio: opts.pixelRatio
-        };
-        if ('tolerance' in opts) {
-            compareOptions.tolerance = opts.tolerance;
-        }
-        return Promise.fromCallback((cb) => {
-            looksSame(path1, path2, compareOptions, cb);
-        });
+        return Promise.fromCallback((cb) => looksSame(path1, path2, opts, cb));
     }
 
     static buildDiff(opts) {

--- a/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
+++ b/lib/state-processor/capture-processor/screen-updater/diff-screen-updater.js
@@ -17,9 +17,10 @@ module.exports = class DiffScreenUpdater extends ScreenUpdater {
 
         return capture.image.save(currentPath)
             .then(() => Image.compare(currentPath, referencePath, {
-                canHaveCaret: capture.canHaveCaret,
+                ignoreCaret: capture.canHaveCaret,
                 tolerance: opts.tolerance,
-                pixelRatio: opts.pixelRatio
+                pixelRatio: opts.pixelRatio,
+                ignoreAntialiasing: true
             }))
             .then((isEqual) => {
                 if (isEqual) {

--- a/lib/state-processor/capture-processor/tester.js
+++ b/lib/state-processor/capture-processor/tester.js
@@ -25,9 +25,10 @@ module.exports = class Tester extends CaptureProcessor {
                     );
             })
             .then(() => Image.compare(currentPath, referencePath, {
-                canHaveCaret: capture.canHaveCaret,
+                ignoreCaret: capture.canHaveCaret,
                 tolerance: opts.tolerance,
-                pixelRatio: opts.pixelRatio
+                pixelRatio: opts.pixelRatio,
+                ignoreAntialiasing: true
             }))
             .then((equal) => ({referencePath, currentPath, equal}));
     }

--- a/lib/state-processor/state-processor.js
+++ b/lib/state-processor/state-processor.js
@@ -20,9 +20,10 @@ module.exports = class StateProcessor {
 
     exec(state, browserSession, page) {
         const coverage = page.coverage;
+        const browserConfig = browserSession.browser.config;
         const tolerance = _.isNumber(state.tolerance)
             ? state.tolerance
-            : browserSession.browser.config.tolerance;
+            : browserConfig.tolerance;
 
         const jobArgs = {
             captureProcessorInfo: this._captureProcessorInfo,
@@ -30,7 +31,8 @@ module.exports = class StateProcessor {
             page: _.omit(page, 'coverage'),
             execOpts: {
                 pixelRatio: page.pixelRatio,
-                refPath: browserSession.browser.config.getScreenshotPath(state.suite, state.name),
+                refPath: browserConfig.getScreenshotPath(state.suite, state.name),
+                ignoreAntialiasing: true,
                 tolerance
             },
             temp: temp.serialize()

--- a/test/unit/image/index.js
+++ b/test/unit/image/index.js
@@ -131,19 +131,16 @@ describe('Image', () => {
 
     it('should compare two images', () => {
         looksSameStub.yields();
-
-        return Image.compare('some/path', 'other/path', {
-            canHaveCaret: true,
+        const compareOpts = {
+            ignoreCaret: true,
             tolerance: 250,
             pixelRatio: 11
-        })
+        };
+
+        return Image.compare('some/path', 'other/path', compareOpts)
             .then(() => {
                 assert.calledOnce(looksSameStub);
-                assert.calledWith(looksSameStub, 'some/path', 'other/path', {
-                    ignoreCaret: true,
-                    tolerance: 250,
-                    pixelRatio: 11
-                });
+                assert.calledWith(looksSameStub, 'some/path', 'other/path', compareOpts);
             });
     });
 

--- a/test/unit/state-processor/capture-processor/tester.js
+++ b/test/unit/state-processor/capture-processor/tester.js
@@ -51,15 +51,17 @@ describe('state-processor/capture-processor/tester', () => {
             const options = {
                 refPath: 'some/ref/path',
                 pixelRatio: 99,
-                tolerance: 23
+                tolerance: 23,
+                ignoreAntialiasing: true
             };
 
             return tester.exec(capture, options)
                 .then(() => {
                     assert.calledWith(Image.compare, 'tmp/path', 'some/ref/path', {
-                        canHaveCaret: true,
+                        ignoreCaret: true,
                         pixelRatio: 99,
-                        tolerance: 23
+                        tolerance: 23,
+                        ignoreAntialiasing: true
                     });
                 });
         });


### PR DESCRIPTION
This browser option allows to ignore diffs that were obtained because of anti-aliased pixels

First we need to publish new `looks-same` version with https://github.com/gemini-testing/looks-same/pull/19