### PR TITLE
npm failed to install due to old polyfill-service dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node-fetch": "^1.6.3",
     "plugins-loader": "^1.0.1",
     "png-img": "^2.1.0",
-    "polyfill-service": "~1.4.0",
+    "polyfill-service": "~3.13.0",
     "q-promise-utils": "^1.1.0",
     "qemitter": "^1.0.0",
     "resolve": "^1.1.0",


### PR DESCRIPTION
By upgrading the polyfill-service, npm or yarn will no longer fail to install because of this message:

```
npm ERR! notsup Unsupported engine for hawk@0.10.2: wanted: {"node":"0.8.x"} (current: {"node":"6.8.1","npm":"3.10.8"})
npm ERR! notsup Not compatible with your version of node/npm: hawk@0.10.2
npm ERR! notsup Not compatible with your version of node/npm: hawk@0.10.2
npm ERR! notsup Required: {"node":"0.8.x"}
npm ERR! notsup Actual:   {"npm":"3.10.8","node":"6.8.1"}
```

In #635 it is mentioned that previously it wasn't possible to update since polyfill-service produced some `console.log`'s that couldn't be hidden, but this was fixed in `3.13.0`.

Fixes #635