### PR TITLE
fix: IE9 does not include pseudo-element styles

### DIFF
--- a/lib/browser/client-scripts/polyfills/getComputedStyle.js
+++ b/lib/browser/client-scripts/polyfills/getComputedStyle.js
@@ -109,6 +109,9 @@ CSSStyleDeclaration.prototype = {
 };
 
 	// <Global>.getComputedStyle
-exports.getComputedStyle = function getComputedStyle(element) {
-    return new CSSStyleDeclaration(element);
+exports.getComputedStyle = function getComputedStyle(element, pseudoEl) {
+    // IE9 needs matchMedia support but already support getComputedStyle
+    return window.getComputedStyle
+        ? window.getComputedStyle(element, pseudoEl)
+        : new CSSStyleDeclaration(element);
 };


### PR DESCRIPTION
@SevInf для IE9 нужно подключать lib.compat, но он поддерживает `getComputedStyle`. Без этого фикса стили для псевдоэлементов не доезжали и блоки с тенью(которые вешаются на них) обрезались