### PR TITLE
Refactoring: remove redundant 'parent' property from Suite

### DIFF
--- a/lib/suite.js
+++ b/lib/suite.js
@@ -41,7 +41,6 @@ module.exports = class Suite {
         suite.name = name;
         suite.path = parent.path ? parent.path.concat(name) : [name];
         suite.context = _.clone(parent.context);
-        suite.parent = parent;
 
         return suite;
     }
@@ -69,9 +68,7 @@ module.exports = class Suite {
         const clonedSuite = Suite.create(this.name, this.parent);
 
         _.forOwn(this, (value, key) => {
-            if (key !== 'parent') {
-                clonedSuite[key] = _.clone(this[key]);
-            }
+            clonedSuite[key] = _.clone(value);
         });
 
         this.children.forEach((child) => clonedSuite.addChild(child.clone()));
@@ -100,7 +97,6 @@ module.exports = class Suite {
 
     addChild(child) {
         Object.setPrototypeOf(child, this);
-        child.parent = this;
         this._children.push(child);
     }
 
@@ -108,7 +104,7 @@ module.exports = class Suite {
         const index = _.indexOf(this._children, suite);
 
         if (index !== -1) {
-            suite.parent = null;
+            Object.setPrototypeOf(suite, Suite.prototype);
             this._children.splice(index, 1);
         }
     }
@@ -119,6 +115,11 @@ module.exports = class Suite {
 
     get isRoot() {
         return !this.parent;
+    }
+
+    get parent() {
+        const proto = Object.getPrototypeOf(this);
+        return proto === Suite.prototype ? null : proto;
     }
 
     get fullName() {


### PR DESCRIPTION
У нас итак уже есть связь `child` -> `parent` - это прототип сьюта. Снес отдельное свойство, добавил геттер, чтобы ничего не поломать.