### PR TITLE
Refactoring: do not pass coverage option through runners

### DIFF
--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -308,7 +308,7 @@ module.exports = class NewBrowser extends Browser {
             usePixelRatio: this._calibration ? this._calibration.usePixelRatio : true
         });
 
-        return this._clientBridge.call('prepareScreenshot', [selectors, opts || {}]);
+        return this._clientBridge.call('prepareScreenshot', [selectors, opts]);
     }
 
     quit() {

--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -199,7 +199,7 @@ module.exports = class NewBrowser extends Browser {
             basedir: path.join(__dirname, 'client-scripts')
         });
 
-        if (!this.config.system.coverage.enabled) {
+        if (!this._coverageEnabled) {
             script.exclude('./gemini.coverage');
         }
 
@@ -227,6 +227,10 @@ module.exports = class NewBrowser extends Browser {
 
                 return scripts;
             });
+    }
+
+    get _coverageEnabled() {
+        return this.config.system.coverage.enabled;
     }
 
     get _needsCompatLib() {
@@ -305,7 +309,8 @@ module.exports = class NewBrowser extends Browser {
 
     prepareScreenshot(selectors, opts) {
         opts = _.extend(opts, {
-            usePixelRatio: this._calibration ? this._calibration.usePixelRatio : true
+            usePixelRatio: this._calibration ? this._calibration.usePixelRatio : true,
+            coverage: this._coverageEnabled
         });
 
         return this._clientBridge.call('prepareScreenshot', [selectors, opts]);

--- a/lib/capture-session/index.js
+++ b/lib/capture-session/index.js
@@ -28,13 +28,10 @@ var CaptureSession = inherit({
         return promiseUtil.sequence(actions, this.browser, new ActionsBuilder(this._postActions));
     },
 
-    prepareScreenshot: function(state, opts) {
-        opts = _.extend({}, opts, {
-            ignoreSelectors: state.ignoreSelectors
-        });
-
+    prepareScreenshot: function(state) {
         this.log('capture "%s" in %o', state.fullName, this.browser);
-        return this.browser.prepareScreenshot(state.captureSelectors, opts);
+        return this.browser.prepareScreenshot(state.captureSelectors,
+            {ignoreSelectors: state.ignoreSelectors});
     },
 
     capture: function(page) {

--- a/lib/runner/state-runner/index.js
+++ b/lib/runner/state-runner/index.js
@@ -4,10 +4,10 @@ const StateRunner = require('./state-runner');
 const DisabledStateRunner = require('./disabled-state-runner');
 const _ = require('lodash');
 
-exports.create = (state, browserSession, config) => {
+exports.create = (state, browserSession) => {
     if (!_.includes(state.browsers, browserSession.browser.id)) {
-        return new DisabledStateRunner(state, browserSession, config);
+        return new DisabledStateRunner(state, browserSession);
     }
 
-    return new StateRunner(state, browserSession, config);
+    return new StateRunner(state, browserSession);
 };

--- a/lib/runner/state-runner/state-runner.js
+++ b/lib/runner/state-runner/state-runner.js
@@ -6,12 +6,11 @@ const Runner = require('../runner');
 const Events = require('../../constants/events');
 
 module.exports = class StateRunner extends Runner {
-    constructor(state, browserSession, config) {
+    constructor(state, browserSession) {
         super();
 
         this._state = state;
         this._browserSession = browserSession;
-        this._config = config;
         this._stateInfo = {
             suite: state.suite,
             state: state,
@@ -26,7 +25,7 @@ module.exports = class StateRunner extends Runner {
         const session = this._browserSession;
 
         return session.runActions(this._state.actions)
-            .then(() => session.prepareScreenshot(this._state, {coverage: this._config.isCoverageEnabled()}))
+            .then(() => session.prepareScreenshot(this._state))
             .catch((e) => session.extendWithPageScreenshot(e).thenThrow(e))
             .then((page) => this._capture(stateProcessor, page))
             .catch((e) => this._emit(Events.ERROR, e))

--- a/lib/runner/suite-runner/insistent-suite-runner.js
+++ b/lib/runner/suite-runner/insistent-suite-runner.js
@@ -15,7 +15,6 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
     constructor(suite, browserAgent, config) {
         super(suite, browserAgent);
 
-        this._config = config;
         this._retries = config.forBrowser(browserAgent.browserId).retry;
         this._retriesPerformed = 0;
     }
@@ -31,7 +30,7 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
     _initSuiteRunner() {
         this._disablePassedStates(this._suite);
 
-        const runner = RegularSuiteRunner.create(this._suite, this._browserAgent, this._config);
+        const runner = RegularSuiteRunner.create(this._suite, this._browserAgent);
 
         this._handleEvent(runner, Events.ERROR, (e) => e instanceof NoRefImageError);
         this._handleEvent(runner, Events.TEST_RESULT, (r) => r.equal);

--- a/lib/runner/suite-runner/regular-suite-runner.js
+++ b/lib/runner/suite-runner/regular-suite-runner.js
@@ -14,14 +14,13 @@ const cloneError = require('../../errors/utils').cloneError;
 const NoRefImageError = require('../../errors/no-ref-image-error');
 
 module.exports = class RegularSuiteRunner extends SuiteRunner {
-    static create(suite, browserAgent, config) {
-        return new RegularSuiteRunner(suite, browserAgent, config);
+    static create(suite, browserAgent) {
+        return new RegularSuiteRunner(suite, browserAgent);
     }
 
-    constructor(suite, browserAgent, config) {
+    constructor(suite, browserAgent) {
         super(suite, browserAgent);
 
-        this._config = config;
         this._session = null;
         this._brokenSession = false;
     }
@@ -97,7 +96,7 @@ module.exports = class RegularSuiteRunner extends SuiteRunner {
     }
 
     _runStateInSession(state, stateProcessor) {
-        const runner = StateRunner.create(state, this._session, this._config);
+        const runner = StateRunner.create(state, this._session);
 
         this.passthroughEvent(runner, [
             Events.SKIP_STATE,

--- a/test/unit/browser-pool/limited-pool.js
+++ b/test/unit/browser-pool/limited-pool.js
@@ -1,8 +1,8 @@
 'use strict';
-var Browser = require('lib/browser'),
-    Promise = require('bluebird'),
+var Promise = require('bluebird'),
     LimitedPool = require('lib/browser-pool/limited-pool'),
     rejectedPromise = require('test/util').rejectedPromise,
+    browserWithId = require('test/util').browserWithId,
     CancelledError = require('lib/errors/cancelled-error');
 
 describe('LimitedPool', function() {
@@ -20,12 +20,7 @@ describe('LimitedPool', function() {
         };
 
         this.makeBrowser = function() {
-            var config = {
-                id: 'id',
-                desiredCapabilities: {browserName: 'id'}
-            };
-
-            return this.sinon.stub(Browser.create(config, 'id'));
+            return this.sinon.stub(browserWithId('id'));
         };
     });
 

--- a/test/unit/browser-pool/limited-pool.js
+++ b/test/unit/browser-pool/limited-pool.js
@@ -1,216 +1,201 @@
 'use strict';
-var Promise = require('bluebird'),
-    LimitedPool = require('lib/browser-pool/limited-pool'),
-    rejectedPromise = require('test/util').rejectedPromise,
-    browserWithId = require('test/util').browserWithId,
-    CancelledError = require('lib/errors/cancelled-error');
+const Promise = require('bluebird');
+const LimitedPool = require('lib/browser-pool/limited-pool');
+const rejectedPromise = require('test/util').rejectedPromise;
+const browserWithId = require('test/util').browserWithId;
+const CancelledError = require('lib/errors/cancelled-error');
 
-describe('LimitedPool', function() {
-    beforeEach(function() {
-        this.underlyingPool = {
+describe('LimitedPool', () => {
+    const sandbox = sinon.sandbox.create();
+    let underlyingPool;
+
+    const makePool_ = (limit) => new LimitedPool(limit || 1, underlyingPool);
+    const makeBrowser_ = () => sandbox.stub(browserWithId('id'));
+
+    beforeEach(() => {
+        underlyingPool = {
             getBrowser: sinon.stub(),
             freeBrowser: sinon.stub().returns(Promise.resolve()),
             cancel: sinon.stub()
         };
-
-        this.sinon = sinon.sandbox.create();
-
-        this.makePool = function(limit) {
-            return new LimitedPool(limit || 1, this.underlyingPool);
-        };
-
-        this.makeBrowser = function() {
-            return this.sinon.stub(browserWithId('id'));
-        };
     });
 
-    afterEach(function() {
-        this.sinon.restore();
-    });
+    afterEach(() => sandbox.restore());
 
-    it('should request browser from underlying pool', function() {
-        var browser = this.makeBrowser();
-        this.underlyingPool.getBrowser.returns(Promise.resolve(browser));
-        var pool = this.makePool();
+    it('should request browser from underlying pool', () => {
+        const browser = makeBrowser_();
+        underlyingPool.getBrowser.returns(Promise.resolve(browser));
+        const pool = makePool_();
+
         return assert.eventually.equal(pool.getBrowser('id'), browser);
     });
 
-    describe('should return browser to underlying pool', function() {
+    describe('should return browser to underlying pool', () => {
         let browser;
         let pool;
 
-        beforeEach(function() {
-            browser = this.makeBrowser();
-            pool = this.makePool();
-            this.underlyingPool.getBrowser.returns(Promise.resolve(browser));
+        beforeEach(() => {
+            browser = makeBrowser_();
+            pool = makePool_();
+            underlyingPool.getBrowser.returns(Promise.resolve(browser));
         });
 
-        it('when freed', function() {
+        it('when freed', () => {
             return pool.freeBrowser(browser)
-                .then(() => assert.calledWith(this.underlyingPool.freeBrowser, browser));
+                .then(() => assert.calledWith(underlyingPool.freeBrowser, browser));
         });
 
-        it('for release if there are no more requests', function() {
+        it('for release if there are no more requests', () => {
             return pool.getBrowser('first')
                 .then(() => pool.freeBrowser(browser))
-                .then(() => assert.calledWith(this.underlyingPool.freeBrowser, browser, {force: true}));
+                .then(() => assert.calledWith(underlyingPool.freeBrowser, browser, {force: true}));
         });
 
-        it('for caching if there is at least one pending request', function() {
+        it('for caching if there is at least one pending request', () => {
             return pool.getBrowser('first')
                 .then(() => {
                     pool.getBrowser('second');
                     return pool.freeBrowser(browser);
                 })
-                .then(() => assert.calledWith(this.underlyingPool.freeBrowser, browser, {force: false}));
+                .then(() => assert.calledWith(underlyingPool.freeBrowser, browser, {force: false}));
         });
 
-        it('for release if there are pending requests but forced to free', function() {
+        it('for release if there are pending requests but forced to free', () => {
             return pool.getBrowser('first')
                 .then(() => {
                     pool.getBrowser('second');
                     return pool.freeBrowser(browser, {force: true});
                 })
-                .then(() => assert.calledWith(this.underlyingPool.freeBrowser, browser, {force: true}));
+                .then(() => assert.calledWith(underlyingPool.freeBrowser, browser, {force: true}));
         });
 
-        it('for caching if there are pending requests', function() {
+        it('for caching if there are pending requests', () => {
             return pool.getBrowser('first')
                 .then(() => {
                     pool.getBrowser('second');
                     pool.getBrowser('third');
                     return pool.freeBrowser(browser);
                 })
-                .then(() => assert.calledWith(this.underlyingPool.freeBrowser, browser, {force: false}));
+                .then(() => assert.calledWith(underlyingPool.freeBrowser, browser, {force: false}));
         });
 
-        it('taking into account number of failed browser requests', function() {
-            const browser = this.makeBrowser();
-            const pool = this.makePool(2);
+        it('taking into account number of failed browser requests', () => {
+            const browser = makeBrowser_();
+            const pool = makePool_(2);
 
-            this.underlyingPool.getBrowser
+            underlyingPool.getBrowser
                 .withArgs('first').returns(Promise.resolve(browser))
                 .withArgs('second').returns(rejectedPromise());
 
-            return Promise.all([
-                pool.getBrowser('first'),
-                pool.getBrowser('second').reflect()
-            ])
+            return Promise
+                .all([
+                    pool.getBrowser('first'),
+                    pool.getBrowser('second').reflect()
+                ])
                 .then(() => pool.freeBrowser(browser))
-                .then(() => assert.calledWith(this.underlyingPool.freeBrowser, browser, {force: true}));
+                .then(() => assert.calledWith(underlyingPool.freeBrowser, browser, {force: true}));
         });
     });
 
-    it('should launch next request from queue on fail to receive browser from underlying pool', function() {
-        var browser = this.makeBrowser(),
-            pool = this.makePool();
+    it('should launch next request from queue on fail to receive browser from underlying pool', () => {
+        var browser = makeBrowser_(),
+            pool = makePool_();
 
-        this.underlyingPool.getBrowser.onFirstCall().returns(rejectedPromise());
-        this.underlyingPool.getBrowser.onSecondCall().returns(Promise.resolve(browser));
+        underlyingPool.getBrowser.onFirstCall().returns(rejectedPromise());
+        underlyingPool.getBrowser.onSecondCall().returns(Promise.resolve(browser));
 
         pool.getBrowser('id').catch(() => {});
 
         assert.eventually.equal(pool.getBrowser('id'), browser);
     });
 
-    describe('limit', function() {
-        it('should launch all browser in limit', function() {
-            var _this = this;
-            this.underlyingPool.getBrowser
-                .withArgs('first').returns(Promise.resolve(this.makeBrowser()))
-                .withArgs('second').returns(Promise.resolve(this.makeBrowser()));
-            var pool = this.makePool(2);
+    describe('limit', () => {
+        it('should launch all browser in limit', () => {
+            underlyingPool.getBrowser
+                .withArgs('first').returns(Promise.resolve(makeBrowser_()))
+                .withArgs('second').returns(Promise.resolve(makeBrowser_()));
+            const pool = makePool_(2);
+
             return Promise.all([pool.getBrowser('first'), pool.getBrowser('second')])
-                .then(function() {
-                    assert.calledTwice(_this.underlyingPool.getBrowser);
-                    assert.calledWith(_this.underlyingPool.getBrowser, 'first');
-                    assert.calledWith(_this.underlyingPool.getBrowser, 'second');
+                .then(() => {
+                    assert.calledTwice(underlyingPool.getBrowser);
+                    assert.calledWith(underlyingPool.getBrowser, 'first');
+                    assert.calledWith(underlyingPool.getBrowser, 'second');
                 });
         });
 
-        it('should not launch browsers out of limit', function() {
-            this.underlyingPool.getBrowser.returns(Promise.resolve(this.makeBrowser()));
-            var pool = this.makePool(1);
-            var result = pool.getBrowser('first')
-                .then(function() {
-                    return pool.getBrowser('second').timeout(100, 'timeout');
-                });
+        it('should not launch browsers out of limit', () => {
+            underlyingPool.getBrowser.returns(Promise.resolve(makeBrowser_()));
+            const pool = makePool_(1);
+
+            const result = pool.getBrowser('first')
+                .then(() => pool.getBrowser('second').timeout(100, 'timeout'));
+
             return assert.isRejected(result, /timeout$/);
         });
 
-        it('should launch next browsers after previous are released', function() {
-            var expectedBrowser = this.makeBrowser(),
-                pool = this.makePool(1);
+        it('should launch next browsers after previous are released', () => {
+            const expectedBrowser = makeBrowser_();
+            const pool = makePool_(1);
 
-            this.underlyingPool.getBrowser
-                .withArgs('first').returns(Promise.resolve(this.makeBrowser()))
+            underlyingPool.getBrowser
+                .withArgs('first').returns(Promise.resolve(makeBrowser_()))
                 .withArgs('second').returns(Promise.resolve(expectedBrowser));
 
-            var result = pool.getBrowser('first')
-                .then(function(browser) {
-                    return pool.freeBrowser(browser);
-                })
-                .then(function() {
-                    return pool.getBrowser('second');
+            const result = pool.getBrowser('first')
+                .then((browser) => pool.freeBrowser(browser))
+                .then(() => pool.getBrowser('second'));
+
+            return assert.eventually.equal(result, expectedBrowser);
+        });
+
+        it('should launch queued browser when previous are released', () => {
+            const expectedBrowser = makeBrowser_();
+            const pool = makePool_(1);
+
+            underlyingPool.getBrowser
+                .withArgs('first').returns(Promise.resolve(makeBrowser_()))
+                .withArgs('second').returns(Promise.resolve(expectedBrowser));
+
+            const result = pool.getBrowser('first')
+                .then((browser) => {
+                    const secondPromise = pool.getBrowser('second');
+                    return Promise.delay(100)
+                        .then(() => pool.freeBrowser(browser))
+                        .then(() => secondPromise);
                 });
 
             return assert.eventually.equal(result, expectedBrowser);
         });
 
-        it('should launch queued browser when previous are released', function() {
-            var expectedBrowser = this.makeBrowser(),
-                pool = this.makePool(1);
+        it('should launch next browsers if free failed', () => {
+            var expectedBrowser = makeBrowser_();
+            const pool = makePool_(1);
 
-            this.underlyingPool.getBrowser
-                .withArgs('first').returns(Promise.resolve(this.makeBrowser()))
+            underlyingPool.getBrowser
+                .withArgs('first').returns(Promise.resolve(makeBrowser_()))
                 .withArgs('second').returns(Promise.resolve(expectedBrowser));
 
+            underlyingPool.freeBrowser.returns(rejectedPromise());
+
             var result = pool.getBrowser('first')
-                .then(function(browser) {
+                .then((browser) => {
                     var secondPromise = pool.getBrowser('second');
                     return Promise.delay(100)
-                        .then(function() {
-                            return pool.freeBrowser(browser);
-                        })
-                        .then(function() {
-                            return secondPromise;
-                        });
-                });
-            return assert.eventually.equal(result, expectedBrowser);
-        });
-
-        it('should launch next browsers if free failed', function() {
-            var expectedBrowser = this.makeBrowser(),
-                pool = this.makePool(1);
-
-            this.underlyingPool.getBrowser
-                .withArgs('first').returns(Promise.resolve(this.makeBrowser()))
-                .withArgs('second').returns(Promise.resolve(expectedBrowser));
-
-            this.underlyingPool.freeBrowser.returns(rejectedPromise());
-
-            var result = pool.getBrowser('first')
-                .then(function(browser) {
-                    var secondPromise = pool.getBrowser('second');
-                    return Promise.delay(100)
-                        .then(function() {
-                            return pool.freeBrowser(browser);
-                        })
-                        .catch(function() {
-                            return secondPromise;
-                        });
+                        .then(() => pool.freeBrowser(browser))
+                        .catch(() => secondPromise);
                 });
 
             return assert.eventually.equal(result, expectedBrowser);
         });
 
-        it('should not wait for queued browser to start after release browser', function() {
-            const pool = this.makePool(1);
+        it('should not wait for queued browser to start after release browser', () => {
+            const pool = makePool_(1);
             const afterFree = sinon.spy().named('afterFree');
             const afterSecondGet = sinon.spy().named('afterSecondGet');
 
-            this.underlyingPool.getBrowser
-                .withArgs('first').returns(Promise.resolve(this.makeBrowser()))
+            underlyingPool.getBrowser
+                .withArgs('first').returns(Promise.resolve(makeBrowser_()))
                 .withArgs('second').returns(Promise.resolve());
 
             return pool.getBrowser('first')
@@ -227,30 +212,29 @@ describe('LimitedPool', function() {
                 });
         });
 
-        it('should reject the queued call when underlying pool rejects the request', function() {
-            var pool = this.makePool(1),
-                error = new Error('You shall not pass');
-            this.underlyingPool.getBrowser
-                .onFirstCall().returns(Promise.resolve(this.makeBrowser()))
+        it('should reject the queued call when underlying pool rejects the request', () => {
+            const pool = makePool_(1);
+            const error = new Error('You shall not pass');
+            underlyingPool.getBrowser
+                .onFirstCall().returns(Promise.resolve(makeBrowser_()))
                 .onSecondCall().returns(rejectedPromise(error));
 
             return pool.getBrowser('id')
-                .then(function(browser) {
-                    var secondRequest = pool.getBrowser('id');
+                .then((browser) => {
+                    const secondRequest = pool.getBrowser('id');
                     return pool.freeBrowser(browser)
-                        .then(function() {
-                            return assert.isRejected(secondRequest, error);
-                        });
+                        .then(() => assert.isRejected(secondRequest, error));
                 });
         });
     });
 
     describe('cancel', () => {
-        it('should cancel queued browsers', function() {
-            var pool = this.makePool(1);
-            this.underlyingPool.getBrowser.returns(Promise.resolve(this.makeBrowser()));
+        it('should cancel queued browsers', () => {
+            const pool = makePool_(1);
+            underlyingPool.getBrowser.returns(Promise.resolve(makeBrowser_()));
+
             return pool.getBrowser('id')
-                .then(function() {
+                .then(() => {
                     var secondRequest = pool.getBrowser('id');
 
                     pool.cancel();
@@ -259,19 +243,19 @@ describe('LimitedPool', function() {
                 });
         });
 
-        it('should cancel an underlying pool', function() {
-            const pool = this.makePool(1);
+        it('should cancel an underlying pool', () => {
+            const pool = makePool_(1);
 
             pool.cancel();
 
-            assert.calledOnce(this.underlyingPool.cancel);
+            assert.calledOnce(underlyingPool.cancel);
         });
 
-        it('should reset request queue', function() {
-            const firstBrowser = this.makeBrowser();
-            const pool = this.makePool(1);
+        it('should reset request queue', () => {
+            const firstBrowser = makeBrowser_();
+            const pool = makePool_(1);
 
-            this.underlyingPool.getBrowser
+            underlyingPool.getBrowser
                 .withArgs('first').returns(Promise.resolve(firstBrowser));
 
             const result = pool.getBrowser('first')
@@ -285,8 +269,8 @@ describe('LimitedPool', function() {
 
             return result
                 .catch(() => {
-                    assert.calledOnce(this.underlyingPool.getBrowser);
-                    assert.neverCalledWith(this.underlyingPool.getBrowser, 'second');
+                    assert.calledOnce(underlyingPool.getBrowser);
+                    assert.neverCalledWith(underlyingPool.getBrowser, 'second');
                 });
         });
     });

--- a/test/unit/browser/new-browser.js
+++ b/test/unit/browser/new-browser.js
@@ -301,6 +301,7 @@ describe('browser/new-browser', () => {
             return launchBrowser_()
                 .then((browser) => browser.prepareScreenshot(['some-selector'], {some: 'opt'}))
                 .then(() => {
+                    assert.calledOnce(ClientBridge.prototype.call);
                     assert.calledWith(ClientBridge.prototype.call, 'prepareScreenshot');
 
                     const selectors = ClientBridge.prototype.call.firstCall.args[1][0];

--- a/test/unit/capture-session/index.js
+++ b/test/unit/capture-session/index.js
@@ -110,13 +110,10 @@ describe('capture session', () => {
                 ignoreSelectors: ['.ignore1', '.ignore2']
             };
 
-            return session.prepareScreenshot(state, {some: 'opt'})
+            return session.prepareScreenshot(state)
                 .then(() => assert.calledWith(browser.prepareScreenshot,
                     ['.selector1', '.selector2'],
-                    {
-                        some: 'opt',
-                        ignoreSelectors: ['.ignore1', '.ignore2']
-                    }
+                    {ignoreSelectors: ['.ignore1', '.ignore2']}
                 ));
         });
     });

--- a/test/unit/runner/state-runner/disabled-state-runner.js
+++ b/test/unit/runner/state-runner/disabled-state-runner.js
@@ -1,13 +1,13 @@
 'use strict';
-var Promise = require('bluebird'),
-    DisabledStateRunner = require('lib/runner/state-runner/disabled-state-runner'),
-    CaptureSession = require('lib/capture-session'),
-    util = require('../../../util');
+const Promise = require('bluebird');
+const DisabledStateRunner = require('lib/runner/state-runner/disabled-state-runner');
+const CaptureSession = require('lib/capture-session');
+const util = require('../../../util');
 
-describe('runner/state-runner/disabled-state-runner', function() {
+describe('runner/state-runner/disabled-state-runner', () => {
     function mkBrowserSessionStub_(opts) {
         opts = opts || {};
-        var session = sinon.createStubInstance(CaptureSession);
+        const session = sinon.createStubInstance(CaptureSession);
         session.browser = util.browserWithId(opts.browserId || 'default-browser-id');
         session.browser.sessionId = opts.sessionId || 'default-session-id';
 
@@ -24,26 +24,24 @@ describe('runner/state-runner/disabled-state-runner', function() {
         return new DisabledStateRunner(state, browserSession);
     }
 
-    it('should perform state actions', function() {
-        var browserSession = mkBrowserSessionStub_(),
-            state = util.makeStateStub(),
-            runner = mkRunner_(state, browserSession);
+    it('should perform state actions', () => {
+        const browserSession = mkBrowserSessionStub_();
+        const state = util.makeStateStub();
+        const runner = mkRunner_(state, browserSession);
 
         return runner.run()
-            .then(function() {
+            .then(() => {
                 assert.calledOnce(browserSession.runActions);
                 assert.calledWith(browserSession.runActions, state.actions);
             });
     });
 
-    it('should not perform capture', function() {
-        var browserSession = mkBrowserSessionStub_(),
-            state = util.makeStateStub(),
-            runner = mkRunner_(state, browserSession);
+    it('should not perform capture', () => {
+        const browserSession = mkBrowserSessionStub_();
+        const state = util.makeStateStub();
+        const runner = mkRunner_(state, browserSession);
 
         return runner.run()
-            .then(function() {
-                assert.notCalled(browserSession.capture);
-            });
+            .then(() => assert.notCalled(browserSession.capture));
     });
 });

--- a/test/unit/runner/state-runner/disabled-state-runner.js
+++ b/test/unit/runner/state-runner/disabled-state-runner.js
@@ -2,7 +2,6 @@
 var Promise = require('bluebird'),
     DisabledStateRunner = require('lib/runner/state-runner/disabled-state-runner'),
     CaptureSession = require('lib/capture-session'),
-    Config = require('lib/config'),
     util = require('../../../util');
 
 describe('runner/state-runner/disabled-state-runner', function() {
@@ -21,9 +20,8 @@ describe('runner/state-runner/disabled-state-runner', function() {
     function mkRunner_(state, browserSession) {
         state = state || util.makeStateStub();
         browserSession = browserSession || mkBrowserSessionStub_();
-        var config = sinon.createStubInstance(Config);
 
-        return new DisabledStateRunner(state, browserSession, config);
+        return new DisabledStateRunner(state, browserSession);
     }
 
     it('should perform state actions', function() {

--- a/test/unit/runner/state-runner/index.js
+++ b/test/unit/runner/state-runner/index.js
@@ -12,11 +12,9 @@ describe('runner/state-runner', () => {
     let DisabledStateRunner;
 
     let sessionStub;
-    let configStub;
 
     beforeEach(() => {
         sessionStub = {browser: {}};
-        configStub = {fake: 'value'};
 
         DisabledStateRunner = sandbox.stub();
 
@@ -38,9 +36,9 @@ describe('runner/state-runner', () => {
     it('should pass state, browser session and config to the constructor of DisabledStateRunner', () => {
         const state = util.makeStateStub();
 
-        StateRunnerFactory.create(state, sessionStub, configStub);
+        StateRunnerFactory.create(state, sessionStub);
 
-        assert.calledWith(DisabledStateRunner, state, sessionStub, configStub);
+        assert.calledWith(DisabledStateRunner, state, sessionStub);
     });
 
     it('should create StateRunner by default', () => {

--- a/test/unit/runner/state-runner/state-runner.js
+++ b/test/unit/runner/state-runner/state-runner.js
@@ -4,7 +4,6 @@ var Promise = require('bluebird'),
     CaptureSession = require('lib/capture-session'),
     StateError = require('lib/errors/state-error'),
     StateProcessor = require('lib/state-processor/state-processor'),
-    Config = require('lib/config'),
     util = require('../../../util');
 
 describe('runner/state-runner/state-runner', function() {
@@ -24,9 +23,8 @@ describe('runner/state-runner/state-runner', function() {
     function mkRunner_(state, browserSession) {
         state = state || util.makeStateStub();
         browserSession = browserSession || mkBrowserSessionStub_();
-        var config = sinon.createStubInstance(Config);
 
-        return new StateRunner(state, browserSession, config);
+        return new StateRunner(state, browserSession);
     }
 
     function mkStateProcessor_() {

--- a/test/unit/runner/state-runner/state-runner.js
+++ b/test/unit/runner/state-runner/state-runner.js
@@ -1,15 +1,15 @@
 'use strict';
-var Promise = require('bluebird'),
-    StateRunner = require('lib/runner/state-runner/state-runner'),
-    CaptureSession = require('lib/capture-session'),
-    StateError = require('lib/errors/state-error'),
-    StateProcessor = require('lib/state-processor/state-processor'),
-    util = require('../../../util');
+const Promise = require('bluebird');
+const StateRunner = require('lib/runner/state-runner/state-runner');
+const CaptureSession = require('lib/capture-session');
+const StateError = require('lib/errors/state-error');
+const StateProcessor = require('lib/state-processor/state-processor');
+const util = require('../../../util');
 
-describe('runner/state-runner/state-runner', function() {
+describe('runner/state-runner/state-runner', () => {
     function mkBrowserSessionStub_(opts) {
         opts = opts || {};
-        var session = sinon.createStubInstance(CaptureSession);
+        const session = sinon.createStubInstance(CaptureSession);
         session.browser = util.browserWithId(opts.browserId || 'default-browser-id');
         session.browser.sessionId = opts.sessionId || 'default-session-id';
 
@@ -28,7 +28,7 @@ describe('runner/state-runner/state-runner', function() {
     }
 
     function mkStateProcessor_() {
-        var stateProcessor = sinon.createStubInstance(StateProcessor);
+        const stateProcessor = sinon.createStubInstance(StateProcessor);
         stateProcessor.exec.returns(Promise.resolve());
         return stateProcessor;
     }
@@ -38,20 +38,20 @@ describe('runner/state-runner/state-runner', function() {
         return runner.run(stateProcessor);
     }
 
-    describe('run', function() {
-        it('should emit `beginState` event', function() {
-            var onBeginState = sinon.spy().named('onBeginState'),
-                browserSession = mkBrowserSessionStub_({
-                    browserId: 'browser',
-                    sessionId: 'session'
-                }),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession);
+    describe('run', () => {
+        it('should emit `beginState` event', () => {
+            const onBeginState = sinon.spy().named('onBeginState');
+            const browserSession = mkBrowserSessionStub_({
+                browserId: 'browser',
+                sessionId: 'session'
+            });
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
 
             runner.on('beginState', onBeginState);
 
             return run_(runner)
-                .then(function() {
+                .then(() => {
                     assert.calledWith(onBeginState, {
                         suite: state.suite,
                         state: state,
@@ -61,19 +61,19 @@ describe('runner/state-runner/state-runner', function() {
                 });
         });
 
-        it('should emit `endState` event', function() {
-            var onEndState = sinon.spy().named('onEndState'),
-                browserSession = mkBrowserSessionStub_({
-                    browserId: 'browser',
-                    sessionId: 'session'
-                }),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession);
+        it('should emit `endState` event', () => {
+            const onEndState = sinon.spy().named('onEndState');
+            const browserSession = mkBrowserSessionStub_({
+                browserId: 'browser',
+                sessionId: 'session'
+            });
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
 
             runner.on('endState', onEndState);
 
             return run_(runner)
-                .then(function() {
+                .then(() => {
                     assert.calledWith(onEndState, {
                         suite: state.suite,
                         state: state,
@@ -83,29 +83,29 @@ describe('runner/state-runner/state-runner', function() {
                 });
         });
 
-        it('should perform state actions', function() {
-            var browserSession = mkBrowserSessionStub_(),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession);
+        it('should perform state actions', () => {
+            const browserSession = mkBrowserSessionStub_();
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
 
             return run_(runner)
-                .then(function() {
+                .then(() => {
                     assert.calledOnce(browserSession.runActions);
                     assert.calledWith(browserSession.runActions, state.actions);
                 });
         });
 
-        it('should perform state actions before processing state', function() {
-            var browserSession = mkBrowserSessionStub_(),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession),
-                mediator = sinon.spy().named('mediator'),
-                stateProcessor = mkStateProcessor_();
+        it('should perform state actions before processing state', () => {
+            const browserSession = mkBrowserSessionStub_();
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
+            const mediator = sinon.spy().named('mediator');
+            const stateProcessor = mkStateProcessor_();
 
             browserSession.runActions.returns(Promise.delay(50).then(mediator));
 
             return run_(runner, stateProcessor)
-                .then(function() {
+                .then(() => {
                     assert.callOrder(
                         browserSession.runActions,
                         mediator,
@@ -114,32 +114,32 @@ describe('runner/state-runner/state-runner', function() {
                 });
         });
 
-        it('should extend error in state actions with page screenshot', function() {
-            var browserSession = mkBrowserSessionStub_(),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession);
+        it('should extend error in state actions with page screenshot', () => {
+            const browserSession = mkBrowserSessionStub_();
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
 
-            var error = new StateError('some error');
+            const error = new StateError('some error');
             browserSession.runActions.returns(Promise.reject(error));
 
             return run_(runner)
-                .then(function() {
+                .then(() => {
                     assert.calledOnce(browserSession.extendWithPageScreenshot);
                     assert.calledWith(browserSession.extendWithPageScreenshot, error);
                 });
         });
 
-        it('should prepare screenshot before processing state', function() {
-            var browserSession = mkBrowserSessionStub_(),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession),
-                mediator = sinon.spy().named('mediator'),
-                stateProcessor = mkStateProcessor_();
+        it('should prepare screenshot before processing state', () => {
+            const browserSession = mkBrowserSessionStub_();
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
+            const mediator = sinon.spy().named('mediator');
+            const stateProcessor = mkStateProcessor_();
 
             browserSession.prepareScreenshot.returns(Promise.delay(500).then(mediator));
 
             return run_(runner, stateProcessor)
-                .then(function() {
+                .then(() => {
                     assert.callOrder(
                         browserSession.prepareScreenshot,
                         mediator,
@@ -148,69 +148,64 @@ describe('runner/state-runner/state-runner', function() {
                 });
         });
 
-        it('should extend prepare screenshot error with page screenshot', function() {
-            var browserSession = mkBrowserSessionStub_(),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession);
+        it('should extend prepare screenshot error with page screenshot', () => {
+            const browserSession = mkBrowserSessionStub_();
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
 
-            var error = new StateError('some error');
+            const error = new StateError('some error');
             browserSession.prepareScreenshot.returns(Promise.reject(error));
 
             return run_(runner)
-                .then(function() {
+                .then(() => {
                     assert.calledOnce(browserSession.extendWithPageScreenshot);
                     assert.calledWith(browserSession.extendWithPageScreenshot, error);
                 });
         });
 
-        it('should process state', function() {
-            var browserSession = mkBrowserSessionStub_(),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state, browserSession),
-                stateProcessor = mkStateProcessor_();
+        it('should process state', () => {
+            const browserSession = mkBrowserSessionStub_();
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state, browserSession);
+            const stateProcessor = mkStateProcessor_();
 
             stateProcessor.exec.returns(Promise.resolve());
 
             return runner.run(stateProcessor)
-                .then(function() {
+                .then(() => {
                     assert.calledOnce(stateProcessor.exec);
                     assert.calledWith(stateProcessor.exec, state, browserSession);
                 });
         });
 
-        it('should extend state errors with metadata', function() {
-            var onStateError = sinon.spy().named('onError'),
-                state = util.makeStateStub(),
-                runner = mkRunner_(state),
-                stateProcessor = mkStateProcessor_();
+        it('should extend state errors with metadata', () => {
+            const onStateError = sinon.spy().named('onError');
+            const state = util.makeStateStub();
+            const runner = mkRunner_(state);
+            const stateProcessor = mkStateProcessor_();
 
             runner.on('err', onStateError);
 
             stateProcessor.exec.returns(Promise.reject(new StateError()));
 
             return run_(runner, stateProcessor)
-                .then(function() {
-                    var error = onStateError.firstCall.args[0];
+                .then(() => {
+                    const error = onStateError.firstCall.args[0];
                     assert.equal(error.state, state);
                     assert.equal(error.suite, state.suite);
                 });
         });
 
-        it('should emit events in correct order', function() {
-            var onBeginState = sinon.spy().named('onBeginState'),
-                onEndState = sinon.spy().named('onEndState'),
-                runner = mkRunner_();
+        it('should emit events in correct order', () => {
+            const onBeginState = sinon.spy().named('onBeginState');
+            const onEndState = sinon.spy().named('onEndState');
+            const runner = mkRunner_();
 
             runner.on('beginState', onBeginState);
             runner.on('endState', onEndState);
 
             return run_(runner)
-                .then(function() {
-                    assert.callOrder(
-                        onBeginState,
-                        onEndState
-                    );
-                });
+                .then(() => assert.callOrder(onBeginState, onEndState));
         });
     });
 });

--- a/test/unit/runner/suite-runner/insistent-suite-runner.js
+++ b/test/unit/runner/suite-runner/insistent-suite-runner.js
@@ -61,7 +61,7 @@ describe('runner/suite-runner/insistent-suite-runner', () => {
             .run()
             .then(() => {
                 assert.calledOnce(RegularSuiteRunner.create);
-                assert.calledWith(RegularSuiteRunner.create, suite, browserAgent, config);
+                assert.calledWith(RegularSuiteRunner.create, suite, browserAgent);
             });
     });
 

--- a/test/unit/runner/suite-runner/regular-suite-runner.js
+++ b/test/unit/runner/suite-runner/regular-suite-runner.js
@@ -7,7 +7,6 @@ const StateRunnerFactory = require('lib/runner/state-runner');
 const StateRunner = require('lib/runner/state-runner/state-runner');
 const CaptureSession = require('lib/capture-session');
 const BrowserAgent = require('lib/runner/browser-runner/browser-agent');
-const Config = require('lib/config');
 const NoRefImageError = require('lib/errors/no-ref-image-error');
 const util = require('../../../util');
 const makeSuiteStub = util.makeSuiteStub;
@@ -20,7 +19,6 @@ describe('runner/suite-runner/regular-suite-runner', () => {
     let stateRunnerFactory;
 
     let browser;
-    let config;
 
     beforeEach(() => {
         browser = util.browserWithId('default-browser');
@@ -37,11 +35,6 @@ describe('runner/suite-runner/regular-suite-runner', () => {
         CaptureSession.prototype.runActions.returns(Promise.resolve());
         CaptureSession.prototype.browser = browser;
 
-        config = sinon.createStubInstance(Config);
-        config.forBrowser.returns({
-            rootUrl: 'http://localhost/foo/default'
-        });
-
         stateRunner = sinon.createStubInstance(StateRunner);
         stateRunnerFactory = sandbox.stub(StateRunnerFactory);
         stateRunnerFactory.create.returns(stateRunner);
@@ -55,8 +48,7 @@ describe('runner/suite-runner/regular-suite-runner', () => {
 
         return RegularSuiteRunner.create(
             suite || makeSuiteStub(),
-            browserAgent,
-            config
+            browserAgent
         );
     };
 

--- a/test/util.js
+++ b/test/util.js
@@ -22,6 +22,9 @@ function browserWithId(id) {
         id,
         desiredCapabilities: {
             browserName: id
+        },
+        system: {
+            coverage: {}
         }
     });
 }


### PR DESCRIPTION
- дописал тестов на `NewBrowser.prepareScreenshot`
- беру опцию `coverage` для клиентского вызова `prepareScreenshot` прямо в инстансе `NewBrowser` вместо того, чтобы прокидывать конфиг через `RegularSuiteRunner`, `StateRunner` и `CaptureSession` в `NewBrowser.prepareScreenshot`