### PR TITLE
Specify output path for reporter path from the CLI

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -66,6 +66,14 @@ You can also use multiple reporters at the same time using multiple
 gemini test --reporter flat --reporter html
 ```
 
+It is possible to specify the output folder for each reporter. In case of html reports, you can set path like this:
+
+```
+gemini test --reporter html --html-reporter-path=tmp/gemini-reports
+```
+
+In the example above the html reporter will save reports in a `tmp/gemini-reports` folder in the project.
+
 ### CSS code coverage (experimental)
 
 Path `--coverage` (or set `coverage` option in config file) to enable code

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -31,6 +31,7 @@ exports.run = () => {
     program.command('test [paths...]')
         .allowUnknownOption(true)
         .option('-r, --reporter <reporter>', 'test reporter. Available reporters are: flat, vflat, html.', collect)
+        .option('--html-reporter-path <path>', 'Relative path where html reporters will be stored', collect)
         .option('-s, --set <set>', 'set to run', collect)
         .description('run tests')
         .action((paths, options) => runGemini('test', paths, options).done());
@@ -96,9 +97,17 @@ function runGemini(method, paths, options) {
         return gemini;
     })
         .then((gemini) => {
+            function parseReporterOptions(options) {
+                return options.reporter.map(function(name) {
+                    return {
+                        name,
+                        path: options[`${name}ReporterPath`]
+                    };
+                });
+            }
             return gemini[method](paths, {
                 sets: options.set,
-                reporters: options.reporter || ['flat'],
+                reporters: parseReporterOptions(options) || [{name: 'flat'}],
                 grep: program.grep,
                 browsers: program.browser,
                 diff: options.diff,

--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -184,17 +184,23 @@ module.exports = class Gemini extends PassthroughEmitter {
 
 function applyReporter(runner, reporter) {
     if (typeof reporter === 'string') {
+        reporter = {name: reporter};
+    }
+    if (typeof reporter === 'object') {
+        const reporterPath = reporter.path;
         try {
-            reporter = require('./reporters/' + reporter);
+            reporter = require('./reporters/' + reporter.name);
         } catch (e) {
             if (e.code === 'MODULE_NOT_FOUND') {
-                throw new GeminiError('No such reporter: ' + reporter);
+                throw new GeminiError('No such reporter: ' + reporter.name);
             }
             throw e;
         }
+
+        return reporter(runner, reporterPath);
     }
     if (typeof reporter !== 'function') {
-        throw new TypeError('Reporter must be a string or a function');
+        throw new TypeError('Reporter must be a string, an object or a function');
     }
 
     reporter(runner);

--- a/lib/reporters/html/index.js
+++ b/lib/reporters/html/index.js
@@ -63,8 +63,8 @@ function logError(e) {
     console.error(e.stack);
 }
 
-function logPathToHtmlReport() {
-    const reportPath = `file://${path.resolve('gemini-report/index.html')}`;
+function logPathToHtmlReport(reporterPath) {
+    const reportPath = `file://${path.resolve((reporterPath || lib.REPORT_DIR) + '/index.html')}`;
 
     logger.log(`Your HTML report is here: ${chalk.yellow(reportPath)}`);
 }
@@ -122,11 +122,11 @@ function prepareImages(runner) {
     });
 }
 
-module.exports = function htmlReporter(runner) {
+module.exports = function htmlReporter(runner, reportPath) {
     const generateReportPromise = Promise.all([prepareViewData(runner), prepareImages(runner)])
         .spread(view.createHtml)
-        .then(view.save)
-        .then(logPathToHtmlReport)
+        .then((html) => view.save(html, reportPath))
+        .then(logPathToHtmlReport(reportPath))
         .catch(logError);
 
     runner.on(Events.END_RUNNER, () => generateReportPromise.thenReturn());

--- a/lib/reporters/html/view.js
+++ b/lib/reporters/html/view.js
@@ -91,8 +91,8 @@ module.exports = {
      * @param {String} html
      * returns {Promise}
      */
-    save: function(html) {
-        return fs.mkdirsAsync(REPORT_DIR)
+    save: function(html, reportPath) {
+        return fs.mkdirsAsync(reportPath || REPORT_DIR)
             .then(() => Promise.all([
                 fs.writeFileAsync(makeOutFilePath('index.html'), html, 'utf8'),
                 copyToReportDir('report.min.js'),


### PR DESCRIPTION
Instead of having hardcoded path for report outputs (now `gemini-reporter`), you can specify this path from cli for each reporter:

`gemini test --reporter=html --html-reporter-path=tmp/gemini-reports`

With command above, all html reports will be generated under tmp/gemini-reports folder in the project where it was run.  Its not tied only to html-reports though. You can specify it as well as for json or any other reporter like this: `--json-reporter-path=.....`