### PR TITLE
feat: Allow to ignore every element, matching selector

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -62,8 +62,10 @@ All methods are chainable:
 
   All tests in a suite will fail if none of the elements will be found.
 
-* `ignoreElements('selector1', 'selector2', ...)` - elements, matching
+* `ignoreElements('.selector1', {every: '.selector2'}, ...)` - elements, matching
   specified selectors will be ignored when comparing images.
+  - `.selector1` - Ignore only the first matched element.
+  - `{every: '.selector2'}` - Ignore all matched elements.
 
 * `setTolerance(value)` - overrides global tolerance value for the whole suite
   (See `tolerance`option description in [config](./config.md) documentation

--- a/lib/browser/client-scripts/gemini.js
+++ b/lib/browser/client-scripts/gemini.js
@@ -114,16 +114,19 @@ function getCaptureRect(selectors) {
 function findIgnoreAreas(selectors) {
     var result = [];
     util.each(selectors, function(selector) {
-        var element = lib.queryFirst(selector);
-        if (element) {
-            var rect = getElementCaptureRect(element);
-            if (rect) {
-                result.push(rect.round().serialize());
-            }
-        }
+        var elements = typeof selector === 'string'
+            ? [lib.queryFirst(selector)]
+            : lib.queryAll(selector.every);
+
+        util.each(elements, addIgnoreArea.bind(result));
     });
 
     return result;
+}
+
+function addIgnoreArea(element) {
+    var rect = element && getElementCaptureRect(element);
+    rect && this.push(rect.round().serialize());
 }
 
 function isHidden(css, clientRect) {

--- a/lib/tests-api/suite-builder.js
+++ b/lib/tests-api/suite-builder.js
@@ -93,8 +93,8 @@ module.exports = function(suite) {
     this.ignoreElements = function ignoreElements() {
         var selectors = argumentsToArray(arguments);
 
-        if (selectors.some(notString)) {
-            throw new TypeError('suite.ignoreElements accepts only strings or array of strings');
+        if (selectors.some(isNotValidSelector)) {
+            throw new TypeError('suite.ignoreElements accepts strings, object with property "every" as string or array of them');
         }
         suite.ignoreSelectors = selectors;
         return this;
@@ -131,6 +131,11 @@ module.exports = function(suite) {
 
 function notString(arg) {
     return typeof arg !== 'string';
+}
+
+// Check if selector is not a string or not an object with "every" option.
+function isNotValidSelector(arg) {
+    return !(_.isString(arg) || (_.isObject(arg) && _.isString(arg.every)));
 }
 
 function argumentsToArray(args) {

--- a/test/unit/tests-api/suite-builder.js
+++ b/test/unit/tests-api/suite-builder.js
@@ -59,41 +59,86 @@ describe('tests-api/suite-builder', function() {
         });
     });
 
-    testSelectorListProperty('setCaptureElements', 'captureSelectors');
-    testSelectorListProperty('ignoreElements', 'ignoreSelectors');
-
-    function testSelectorListProperty(method, property) {
-        describe(method, function() {
-            it ('should throw if selector is not a string', function() {
-                assert.throws(function() {
-                    suiteBuilder[method]({everything: true});
-                }, TypeError);
-            });
-
-            it ('should throw if selector in array is not a string', function() {
-                assert.throws(function() {
-                    suiteBuilder[method]([{everything: true}, '.selector']);
-                }, TypeError);
-            });
-
-            it('should set ' + property + ' property', function() {
-                suiteBuilder[method]('.selector');
-
-                assert.deepEqual(suite[property], ['.selector']);
-            });
-
-            it('should accept multiple arguments', function() {
-                suiteBuilder[method]('.selector1', '.selector2');
-                assert.deepEqual(suite[property], ['.selector1', '.selector2']);
-            });
-
-            it('should accept array', function() {
-                suiteBuilder[method](['.selector1', '.selector2']);
-
-                assert.deepEqual(suite[property], ['.selector1', '.selector2']);
-            });
+    describe('setCaptureElements', function() {
+        it('should throw if selector is not a string', function() {
+            assert.throws(function() {
+                suiteBuilder.setCaptureElements({everything: true});
+            }, TypeError);
         });
-    }
+
+        it('should throw if selector in array is not a string', function() {
+            assert.throws(function() {
+                suiteBuilder.setCaptureElements([{everything: true}, '.selector']);
+            }, TypeError);
+        });
+
+        it('should set captureSelectors property', function() {
+            suiteBuilder.setCaptureElements('.selector');
+
+            assert.deepEqual(suite.captureSelectors, ['.selector']);
+        });
+
+        it('should accept multiple arguments', function() {
+            suiteBuilder.setCaptureElements('.selector1', '.selector2');
+            assert.deepEqual(suite.captureSelectors, ['.selector1', '.selector2']);
+        });
+
+        it('should accept array', function() {
+            suiteBuilder.setCaptureElements(['.selector1', '.selector2']);
+
+            assert.deepEqual(suite.captureSelectors, ['.selector1', '.selector2']);
+        });
+    });
+
+    describe('ignoreElements', function() {
+        it('should throw if selector is a null', function() {
+            assert.throws(function() {
+                suiteBuilder.ignoreElements(null);
+            }, TypeError);
+        });
+
+        it('should throw if selector is object without property "every"', function() {
+            assert.throws(function() {
+                suiteBuilder.ignoreElements({});
+            }, TypeError);
+        });
+
+        it('should throw if selector is an object with property "every" that not a string', function() {
+            assert.throws(function() {
+                suiteBuilder.ignoreElements({every: null});
+            }, TypeError);
+        });
+
+        it('should throw if one of selectors in array has wrong type', function() {
+            assert.throws(function() {
+                suiteBuilder.ignoreElements([{every: true}, '.selector']);
+            }, TypeError);
+        });
+
+        it('should set ignoreSelectors property as string', function() {
+            suiteBuilder.ignoreElements('.selector');
+
+            assert.deepEqual(suite.ignoreSelectors, ['.selector']);
+        });
+
+        it('should set ignoreSelectors property as object with property "every"', function() {
+            suiteBuilder.ignoreElements({every: '.selector'});
+
+            assert.deepEqual(suite.ignoreSelectors, [{every: '.selector'}]);
+        });
+
+        it('should accept multiple arguments', function() {
+            suiteBuilder.ignoreElements('.selector1', {every: '.selector2'});
+
+            assert.deepEqual(suite.ignoreSelectors, ['.selector1', {every: '.selector2'}]);
+        });
+
+        it('should accept array', function() {
+            suiteBuilder.ignoreElements(['.selector1', {every: '.selector2'}]);
+
+            assert.deepEqual(suite.ignoreSelectors, ['.selector1', {every: '.selector2'}]);
+        });
+    });
 
     describe('before', function() {
         beforeEach(function() {


### PR DESCRIPTION
Сейчас чтобы игнорировать все картинки, нужно написать точный селектор до каждого экземпляра так как для их поиска используется `document.querySelector`, возвращающий первый найденный элемент.
После влития PR можно будет скрывать все элементы найденные по селектору. Достаточно передать не строку, а объект `suite.ignoreElements({every: '.agency-icon'})`, как предложил @SevInf #191.
