### PR TITLE
fix: 'update' command

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -97,17 +97,9 @@ function runGemini(method, paths, options) {
         return gemini;
     })
         .then((gemini) => {
-            function parseReporterOptions(options) {
-                return options.reporter.map(function(name) {
-                    return {
-                        name,
-                        path: options[`${name}ReporterPath`]
-                    };
-                });
-            }
             return gemini[method](paths, {
                 sets: options.set,
-                reporters: parseReporterOptions(options) || [{name: 'flat'}],
+                reporters: parseReporterOptions(options),
                 grep: program.grep,
                 browsers: program.browser,
                 diff: options.diff,
@@ -122,6 +114,19 @@ function runGemini(method, paths, options) {
         })
         .catch(handleErrors)
         .then(exit);
+}
+
+function parseReporterOptions(options) {
+    if (!options.reporter) {
+        return [{name: 'flat'}];
+    }
+
+    return options.reporter.map(function(name) {
+        return {
+            name,
+            path: options[`${name}ReporterPath`]
+        };
+    });
 }
 
 function exit(code) {


### PR DESCRIPTION
При запуске команды `gemini update` значение `options.reporter === undefined`, поэтому запуск падает с ошибкой `Can not read property .map of undefined`

Поломано [тут](https://github.com/gemini-testing/gemini/pull/691#discussion_r93614588)

сс @sipayRT 