### PR TITLE
fix: handle default reporter and prevent map on undefined

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -98,7 +98,9 @@ function runGemini(method, paths, options) {
     })
         .then((gemini) => {
             function parseReporterOptions(options) {
-                return options.reporter.map(function(name) {
+                const reporters = options.reporter || ['flat'];
+
+                return reporters.map(function(name) {
                     return {
                         name,
                         path: options[`${name}ReporterPath`]
@@ -107,7 +109,7 @@ function runGemini(method, paths, options) {
             }
             return gemini[method](paths, {
                 sets: options.set,
-                reporters: parseReporterOptions(options) || [{name: 'flat'}],
+                reporters: parseReporterOptions(options),
                 grep: program.grep,
                 browsers: program.browser,
                 diff: options.diff,


### PR DESCRIPTION
Fix default reporter value and possibility to have undefined value for reporters as mentioned here https://github.com/gemini-testing/gemini/pull/691/files#r93614588