### PR TITLE
fix: prevent endless loop when suitesPerSession is set to infinity

### DIFF
--- a/lib/runner/browser-runner/browser-agent.js
+++ b/lib/runner/browser-runner/browser-agent.js
@@ -17,7 +17,7 @@ module.exports = class BrowserAgent {
         return this._pool.getBrowser(this.browserId)
             .then((browser) => {
                 if (_.includes(this._sessions, browser.sessionId)) {
-                    return this.freeBrowser(browser).then(() => this.getBrowser());
+                    return this.freeBrowser(browser, {force: true}).then(() => this.getBrowser());
                 }
 
                 this._sessions.push(browser.sessionId);

--- a/test/unit/runner/browser-runner/browser-agent.js
+++ b/test/unit/runner/browser-runner/browser-agent.js
@@ -48,7 +48,7 @@ describe('runner/browser-runner/browser-agent', () => {
             .then((bro) => {
                 assert.equal(bro, otherBro);
                 assert.calledTwice(browserPool.getBrowser);
-                assert.calledWith(browserPool.freeBrowser, someBro);
+                assert.calledWith(browserPool.freeBrowser, someBro, {force: true});
             });
     });
 


### PR DESCRIPTION
Hi guys.

After recent update from 4.9.3 to 4.14.3 (and 4.16.0) we found our gemini tests being stuck before a first retry attempt. Selenium server output was similar to #651.

We do not specify `suitesPerSession` in the gemini config file, so it is equal to `Infinity`. `LimitedUseSet` is not limited at all in this case. It turned out that `getBrowser` method failed to quit previous session because force quit is missing in the `freeBrowser` method call, and `getBrowser` was called again and again recursively. If `{force: true}` is missing, `CachingPool` implementation puts session back to cache again in every `freeBrowser` call.