### PR TITLE
Add description of reports to help

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -30,10 +30,17 @@ exports.run = () => {
 
     program.command('test [paths...]')
         .allowUnknownOption(true)
-        .option('-r, --reporter <reporter>', 'test reporter. Available reporters are: flat, vflat, html.', collect)
-        .option('--html-reporter-path <path>', 'Relative path where html reporters will be stored', collect)
+        .option('-r, --reporter <reporter>', 'test result reporter (flat by default)', collect)
+        .option('--html-reporter-path <path>', 'relative path where html reporters will be stored', collect)
         .option('-s, --set <set>', 'set to run', collect)
         .description('run tests')
+        .on('--help', () => {
+            console.log('  Reporters:');
+            console.log('    flat    console reporter');
+            console.log('    vflat   verbose console reporter');
+            console.log('    html    HTML reporter. Result stored in \'gemini-report\' directory');
+            console.log('');
+        })
         .action((paths, options) => runGemini('test', paths, options).done());
 
     program.on('--help', () => {


### PR DESCRIPTION
```
gemini $ bin/gemini test --help

  Usage: test [options] [paths...]

  run tests

  Options:

    -h, --help                   output usage information
    -r, --reporter <reporter>    test result reporter (flat by default)
    --html-reporter-path <path>  relative path where html reporters will be stored
    -s, --set <set>              set to run

  Reporters:
    flat    console reporter
    vflat   verbose console reporter
    html    HTML reporter. Result stored in 'gemini-report' directory

gemini $
```