### PR TITLE
fix: roll back striptags version without breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "resolve": "^1.1.0",
     "sizzle": "^2.2.0",
     "source-map": "^0.5.3",
-    "striptags": "^2.1.1",
+    "striptags": "2.1.1",
     "temp": "~0.8.0",
     "uglify-js": "^2.7.3",
     "uglifyify": "^3.0.1",


### PR DESCRIPTION
current striptags version - 2.2.0 has breaking changes and it works only with nodejs 6 and upper