### PR TITLE
Cleanup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "main": "api.js",
   "dependencies": {
     "aliasify": "^1.7.2",
-    "app-module-path": "^1.1.0",
     "bluebird": "^3.4.6",
     "bluebird-q": "^2.1.1",
     "browserify": "^13.0.0",
@@ -24,10 +23,8 @@
     "gemini-configparser": "^0.1.1",
     "gemini-core": "^1.0.0",
     "gemini-coverage": "^1.0.0",
-    "glob-extra": "^2.0.0",
     "handlebars": "^4.0.5",
     "inherit": "~2.2.1",
-    "install": "^0.6.1",
     "js-yaml": "^3.2.5",
     "lodash": "^4.15.0",
     "looks-same": "^3.0.0",
@@ -48,6 +45,7 @@
     "worker-farm": "^1.3.1"
   },
   "devDependencies": {
+    "app-module-path": "^1.1.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "conventional-changelog-lint": "^1.0.1",
@@ -55,6 +53,7 @@
     "eslint": "^3.1.1",
     "eslint-config-gemini-testing": "^2.0.0",
     "gitbook-cli": "^2.3.0",
+    "glob-extra": "^2.0.0",
     "husky": "^0.11.4",
     "istanbul": "^0.4.5",
     "mocha": "^2.1.0",


### PR DESCRIPTION
`app-module-path` and `glob-extra` seem to be only used in tests, so moved to devDependencies.

`install` does not seem to be used at all , I comes from #182 but I don't see it being used @SevInf 