### PR TITLE
chore: update standard-version dependency to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mocha": "^2.1.0",
     "proxyquire": "^1.7.3",
     "sinon": "^1.17.3",
-    "standard-version": "^3.0.0"
+    "standard-version": "^4.0.0"
   },
   "scripts": {
     "test-unit": "istanbul test _mocha -- --recursive test/unit",


### PR DESCRIPTION
@sipayRT @eGavr @j0tunn 

Standard version 4.0.0 includes very useful option called `--release-as` which value can be `major`, `minor` or `patch`.