### PR TITLE
feat(*): add system/testFormats option to config

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -87,6 +87,13 @@ settings. These settings can not be set per-browser.
   After run created directory will be removed. If not set system temp
   directory will be used.
 
+* `testFormats` - array of filename extensions for tests to proceed. `.js` is available by default, override this if you want:
+
+```yaml
+testFormats:
+  - .jsx
+```
+
 * `exclude` - array of glob patterns to exclude paths from the test search. For example:
 
 ```yaml
@@ -147,7 +154,7 @@ exclude:
 
   - `html` - set to false to disable html report and save only JSON.
 
-* `ctx` – a context which will be available in tests via method `gemini.ctx`. 
+* `ctx` – a context which will be available in tests via method `gemini.ctx`.
 
 ## Browsers settings
 

--- a/lib/config/options.js
+++ b/lib/config/options.js
@@ -98,6 +98,20 @@ module.exports = root(
                 map: (value) => [].concat(value)
             }),
 
+            testFormats: option({
+                defaultValue: ['.js'],
+                validate: (value) => {
+                    if (_.isString(value)) {
+                        return;
+                    }
+
+                    if (!_.every(value, _.isString)) {
+                        throw new GeminiError('"testFormats" must be an array of strings');
+                    }
+                },
+                map: (value) => [].concat(value)
+            }),
+
             ctx: anyObject()
         }),
 

--- a/lib/test-reader.js
+++ b/lib/test-reader.js
@@ -31,6 +31,9 @@ module.exports = (emitter, config, opts) => {
         .useSets(opts.sets)
         .useFiles(opts.paths)
         .useBrowsers(opts.browsers)
-        .build(config.system.projectRoot, {ignore: config.system.exclude})
+        .build({
+            root: config.system.projectRoot,
+            formats: config.system.testFormats
+        }, {ignore: config.system.exclude})
         .then((setCollection) => loadSuites(setCollection, emitter, config));
 };


### PR DESCRIPTION
For using not only .js extensions in tests.

https://github.com/gemini-testing/gemini-core/pull/5