### PR TITLE
docs: 'window.scrollTo' does not work in Opera@12.16 driver

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -147,7 +147,7 @@ exclude:
 
   - `html` - set to false to disable html report and save only JSON.
 
-* `ctx` – a context which will be available in tests via method `gemini.ctx`. 
+* `ctx` – a context which will be available in tests via method `gemini.ctx`.
 
 ## Browsers settings
 
@@ -233,6 +233,8 @@ Settings list:
 * `compositeImage` – allows testing of regions which bottom bounds are outside of a viewport height (default: `false`).
   In the resulting screenshot the area which fits the viewport bounds will be **joined** with the area which is outside
   of the viewport height.
+
+  :warning: Option does not work in Opera@12.16.
 
 ## Sets
 

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -255,6 +255,8 @@ call:
    Note that function is executed in a browser context, so any references to
    outer scope of callback won't work.
 
+   :warning: `window.scrollTo` does not work in Opera@12.16 (see [details](https://github.com/operasoftware/operaprestodriver/issues/108)).
+
 * `wait(milliseconds)` – wait for specified amount of time before next action.
   If it is the last action in sequence, delay the screenshot for this amount
   of time.


### PR DESCRIPTION
https://github.com/operasoftware/operaprestodriver/issues/108

cc @sipayRT @j0tunn 