### PR TITLE
fix: enable correct suite through suite collection api

### DIFF
--- a/lib/suite-collection.js
+++ b/lib/suite-collection.js
@@ -106,13 +106,14 @@ module.exports = class SuiteCollection {
     }
 
     _disableEntity(obj, browser) {
-        this._originalBrowsers[obj.fullName] = obj.browsers;
+        this._originalBrowsers[obj.fullName + obj.file] = obj.browsers;
         obj.browsers = browser ? _.without(obj.browsers, browser) : [];
     }
 
     _enableEntity(obj, browser) {
-        if (!browser && this._originalBrowsers[obj.fullName]) {
-            obj.browsers = _.union(obj.browsers, this._originalBrowsers[obj.fullName]);
+        const suiteKey = obj.fullName + obj.file;
+        if (!browser && this._originalBrowsers[suiteKey]) {
+            obj.browsers = _.union(obj.browsers, this._originalBrowsers[suiteKey]);
         }
 
         if (browser) {

--- a/test/unit/suite-collection.js
+++ b/test/unit/suite-collection.js
@@ -2,6 +2,7 @@
 
 const proxyquire = require('proxyquire');
 const mkTree = require('../util').makeSuiteTree;
+const mkSuite = require('../util').makeSuiteStub;
 
 describe('suite-collection', () => {
     const sandbox = sinon.sandbox.create();
@@ -383,6 +384,26 @@ describe('suite-collection', () => {
                     .enable(tree.child.fullName);
 
                 assert.deepEqual(tree.child.browsers, ['b1', 'b2']);
+            });
+
+            it('should enable only current suite if there are the same suites exists in the tree', () => {
+                const suite1 = mkSuite({
+                    name: 'suite',
+                    browsers: ['b1', 'b2'],
+                    file: 'some/path.js'
+                });
+                const suite2 = mkSuite({
+                    name: 'suite',
+                    browsers: ['b3', 'b4'],
+                    file: 'another/path.js'
+                });
+
+                new SuiteCollection([suite1, suite2])
+                    .disableAll()
+                    .enable(suite1);
+
+                assert.deepEqual(suite1.browsers, ['b1', 'b2']);
+                assert.deepEqual(suite2.browsers, []);
             });
 
             it('should fail on attempt to enable unknown suite', () => {

--- a/test/util.js
+++ b/test/util.js
@@ -47,6 +47,7 @@ function makeSuiteStub(opts) {
         suite.addState(state);
     });
     suite.url = opts.url;
+    suite.file = opts.file;
 
     return suite;
 }


### PR DESCRIPTION
If there are 2 suites with equal names suiteCollection.enable will enable first suite