### PR TITLE
Executejs arguments

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -243,17 +243,17 @@ call:
 * `flick(offsets, speed, element)` — flick element with starting point at its
   center by `offsets.x` and `offset.y` offsets.
 
-* `executeJS(function(window))` — run specified function in a browser. The
-  argument of a function is the browser's `window` object:
+* `executeJS(function(window, [args]), [args])` — run specified function in a browser. The
+  argument of a function is the browser's `window` object and optional arguments:
 
   ```js
-  actions.executeJS(function(window) {
-      window.alert('Hello!');
-  });
+  actions.executeJS(function(window, name) {
+      window.alert('Hello!', name);
+  }, name);
   ```
 
    Note that function is executed in a browser context, so any references to
-   outer scope of callback won't work.
+   outer scope of callback won't work unless passed via args.
 
    :warning: `window.scrollTo` does not work in Opera@12.16 (see [details](https://github.com/operasoftware/operaprestodriver/issues/108)).
 

--- a/lib/tests-api/actions-builder.js
+++ b/lib/tests-api/actions-builder.js
@@ -306,13 +306,13 @@ module.exports = inherit({
         return this;
     },
 
-    executeJS: function(callback) {
+    executeJS: function(callback, args) {
         if (typeof callback !== 'function') {
             throw new TypeError('executeJS argument should be function');
         }
 
         this._pushAction(this.executeJS, function executeJS(browser) {
-            return browser.execute(serializeFunc(callback));
+            return browser.execute(serializeFunc(callback), args);
         });
         return this;
     },
@@ -392,7 +392,7 @@ function replaceStack(error, stack) {
 }
 
 function serializeFunc(func) {
-    return '(' + func.toString() + '(window));';
+    return '(' + func.toString() + ').apply(null, [window].concat(Array.prototype.slice.call(arguments)));';
 }
 
 function findElement(element, browser) {


### PR DESCRIPTION
I want to be able to pass arguments into executeJS. It seems this functionality would be useful to others based on #429.  I found this approach in #284, which appears to have been rejected because of the other changes it included. 

I searched the tests for executeJS and serializeFunc, but was unable to find an obvious place to add new tests for this feature. If this looks ok, please let me know where I should add tests.  