### PR TITLE
Added charset to report template

### DIFF
--- a/lib/reporters/html/templates/report.hbs
+++ b/lib/reporters/html/templates/report.hbs
@@ -3,6 +3,7 @@
     <head>
         <title>Gemini report</title>
         <link rel="stylesheet" type="text/css" href="report.css">
+        <meta charset="utf-8">
     </head>
 
     <body class="report">


### PR DESCRIPTION
This fixes, for example, cyrillic test names in report, when you open it with default link with file:// prefix