### PR TITLE
Stacktraces of custom error types should include the error message

### DIFF
--- a/lib/errors/cancelled-error.js
+++ b/lib/errors/cancelled-error.js
@@ -2,10 +2,7 @@
 
 module.exports = class CancelledError extends Error {
     constructor() {
-        super();
-
+        super('Browser request was cancelled');
         this.name = 'CancelledError';
-        this.message = 'Browser request was cancelled';
-        Error.captureStackTrace(this, CancelledError);
     }
 };

--- a/lib/errors/gemini-error.js
+++ b/lib/errors/gemini-error.js
@@ -1,16 +1,10 @@
 'use strict';
-/**
- * Special type of error that intended to be reported
- * to user. Will not print stack trace by default.
- */
-function GeminiError(message, advice) {
-    Error.captureStackTrace(this, GeminiError);
-    this.name = 'GeminiError';
-    this.message = message;
-    this.advice = advice;
-}
 
-GeminiError.prototype = Object.create(Error.prototype);
-GeminiError.prototype.constructor = GeminiError;
+module.exports = class GeminiError extends Error {
+    constructor(message, advice) {
+        super(message);
 
-module.exports = GeminiError;
+        this.name = 'GeminiError';
+        this.advice = advice;
+    }
+};

--- a/lib/errors/no-ref-image-error.js
+++ b/lib/errors/no-ref-image-error.js
@@ -1,22 +1,14 @@
 'use strict';
 
-var inherit = require('inherit'),
-    StateError = require('./state-error');
+const StateError = require('./state-error');
 
-var NoRefImageError = inherit(StateError, {
-    /**
-     * @constructor
-     * @param {String} refImagePath
-     * @param {StateResult} result
-     */
-    __constructor: function(refImagePath, currentPath) {
+module.exports = class NoRefImageError extends StateError {
+    constructor(refImagePath, currentPath) {
+        super(`Can not find reference image at ${refImagePath}.\n` +
+            'Run `gemini update` command to capture all reference images.');
+
         this.name = 'NoRefImageError';
-        this.message = 'Can not find reference image at ' + refImagePath + '.\n' +
-            'Run `gemini update` command to capture all reference images.';
-
         this.currentPath = currentPath;
         this.refImagePath = refImagePath;
     }
-});
-
-module.exports = NoRefImageError;
+};

--- a/lib/errors/state-error.js
+++ b/lib/errors/state-error.js
@@ -4,14 +4,12 @@
  * Non-fatal error, occurred during state run.
  * Fails only single state, not the whole app.
  */
-function StateError(message, originalError) {
-    Error.captureStackTrace(this, StateError);
-    this.name = 'StateError';
-    this.message = message;
-    this.originalError = originalError;
-}
 
-StateError.prototype = Object.create(Error.prototype);
-StateError.prototype.constructor = StateError;
+module.exports = class StateError extends Error {
+    constructor(message, originalError) {
+        super(message);
 
-module.exports = StateError;
+        this.name = 'StateError';
+        this.originalError = originalError;
+    }
+};

--- a/test/unit/errors/cancelled-error.js
+++ b/test/unit/errors/cancelled-error.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const CancelledError = require('lib/errors/cancelled-error');
+
+describe('CancelledError', function() {
+    it('should include the error message in the stacktrace', function() {
+        const error = new CancelledError();
+
+        assert.match(error.stack, /^CancelledError: Browser request was cancelled\n/);
+    });
+});

--- a/test/unit/errors/gemini-error.js
+++ b/test/unit/errors/gemini-error.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const GeminiError = require('lib/errors/gemini-error');
+
+describe('GeminiError', function() {
+    it('should include the given error message in the stacktrace', function() {
+        const error = new GeminiError('MyCustomErrorMessage');
+
+        assert.match(error.stack, /^GeminiError: MyCustomErrorMessage\n/);
+    });
+});

--- a/test/unit/errors/no-ref-image-error.js
+++ b/test/unit/errors/no-ref-image-error.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const NoRefImageError = require('lib/errors/no-ref-image-error');
+
+describe('NoRefImageError', function() {
+    it('should include the error message in the stacktrace', function() {
+        const error = new NoRefImageError('anyPath');
+
+        assert.match(error.stack, /^NoRefImageError: Can not find reference image at anyPath.\n/);
+    });
+});

--- a/test/unit/errors/state-error.js
+++ b/test/unit/errors/state-error.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const StateError = require('lib/errors/state-error');
+
+describe('StateError', function() {
+    it('should include the given error message in the stacktrace', function() {
+        const error = new StateError('MyCustomErrorMessage');
+
+        assert.match(error.stack, /^StateError: MyCustomErrorMessage\n/);
+    });
+});


### PR DESCRIPTION
We are using the [`html-reporter`](https://github.com/gemini-testing/html-reporter) to create reports on our CI system. Sometimes it happens that the connection to our selenium grid fails. The HTML report is then full of errors without the actual error message because [`html-reporter` only shows the stacktrace](https://github.com/gemini-testing/html-reporter/blob/77d4ab54278e85bfb84369681d5611d0751f2570/lib/view-model.js#L77).

<img width="1185" alt="screen shot 2017-08-23 at 16 58 10" src="https://user-images.githubusercontent.com/169170/29622832-c7187ee8-8824-11e7-8bbe-937af1c35b9e.png">

The stacktraces don’t include an error message because in some of the custom error types (e.g. `GeminiError`) `Error.captureStackTrace` was **called before** the message was set.

I’ve added some tests to check that for all custom errors in `lib/errors` the error message will be included in the stacktrace. I’ve also changed the implementation of some custom error types to use ES6 classes which makes the use of `Error.captureStackTrace` unnecessary.
