### PR TITLE
Use 'prepublishOnly' hook instead 'prepublish' to prepare calibrate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "test-unit": "istanbul test _mocha -- --recursive test/unit",
-    "prepublish": "npm run prepare-calibrate-script",
+    "prepublishOnly": "npm run prepare-calibrate-script",
     "prepare-calibrate-script": "uglifyjs ./lib/browser/client-scripts/gemini.calibrate.js -m > ./lib/browser/client-scripts/gemini.calibrate.min.js --support-ie8",
     "postpublish": "npm run publish-site",
     "test-func": "istanbul test _mocha test/functional",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "source-map": "^0.5.3",
     "striptags": "2.1.1",
     "temp": "~0.8.0",
-    "uglify-js": "^2.7.3",
     "uglifyify": "^3.0.1",
     "wd": "^0.4.0",
     "worker-farm": "^1.3.1"
@@ -59,7 +58,8 @@
     "mocha": "^2.1.0",
     "proxyquire": "^1.7.3",
     "sinon": "^2.2.0",
-    "standard-version": "^4.0.0"
+    "standard-version": "^4.0.0",
+    "uglify-js": "^2.7.3"
   },
   "scripts": {
     "test-unit": "istanbul test _mocha -- --recursive test/unit",


### PR DESCRIPTION
I don't understand why we minify calibrate script in prepublish hook which is launched on `npm install` too. Issue about it - https://github.com/npm/npm/issues/16685

I propose do it only before publish new version and it gives us opportunity to transfer uglify-js to dev deps.