### PR TITLE
feat: introduce option to specify delay before any screenshot is made

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -236,6 +236,11 @@ Settings list:
 
   :warning: Option does not work in Opera@12.16.
 
+* `screenshotDelay` — allows to specify a delay (in milliseconds) before making any screenshot.
+  By default there is no delay.
+
+  This is useful when the page has elements which are animated.
+
 ## Sets
 
 You can link some set of tests with certain browsers using `sets`.

--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const Promise = require('bluebird');
 const wd = require('./wd-bluebird');
 
 const Camera = require('./camera');
@@ -17,11 +18,12 @@ module.exports = class Browser {
     }
 
     captureViewportImage(page) {
-        return this._camera.captureViewportImage(page);
+        return Promise.delay(this.config.screenshotDelay)
+            .then(() => this._camera.captureViewportImage(page));
     }
 
     serialize() {
-        const props = ['id', 'gridUrl', 'httpTimeout', 'screenshotMode', 'compositeImage'];
+        const props = ['id', 'gridUrl', 'httpTimeout', 'screenshotMode', 'screenshotDelay', 'compositeImage'];
 
         return {
             config: _.pick(this.config, props),

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -29,7 +29,8 @@ const getTopLevel = () => {
         windowSize: null,
         retry: 0,
         screenshotMode: 'auto',
-        compositeImage: false
+        compositeImage: false,
+        screenshotDelay: 0
     };
 
     const provideDefault = (key) => defaults[key];
@@ -204,6 +205,15 @@ function buildBrowserOptions(defaultFactory, extra) {
                 if (!_.includes(['fullpage', 'viewport', 'auto'], value)) {
                     throw new GeminiError('"screenshotMode" must be one of "fullpage", "viewport" or "auto"');
                 }
+            }
+        }),
+
+        screenshotDelay: option({
+            defaultValue: defaultFactory('screenshotDelay'),
+            parseEnv: Number,
+            parseCli: Number,
+            validate: (value) => {
+                assertNonNegative(value, 'screenshotDelay');
             }
         }),
 

--- a/test/unit/browser/new-browser.js
+++ b/test/unit/browser/new-browser.js
@@ -421,16 +421,25 @@ describe('browser/new-browser', () => {
     });
 
     describe('captureViewportImage', () => {
-        let browser;
-
         beforeEach(() => {
             sandbox.stub(Camera.prototype, 'captureViewportImage');
+            sandbox.stub(Promise, 'delay').returns(Promise.resolve());
+        });
 
-            browser = makeBrowser({browserName: 'browser', version: '1.0'}, {calibrate: true});
+        it('should delay capturing by the configured amount', () => {
+            const browser = makeBrowser({browserName: 'browser', version: '1.0'}, {calibrate: false, screenshotDelay: 42});
+
+            return browser.launch()
+                .then(() => browser.captureViewportImage())
+                .then(() => {
+                    assert.calledOnce(Promise.delay);
+                    assert.calledWith(Promise.delay, 42);
+                    assert.callOrder(Promise.delay, Camera.prototype.captureViewportImage);
+                });
         });
 
         it('should delegate actual capturing to camera object', () => {
-            browser = makeBrowser({browserName: 'browser', version: '1.0'}, {calibrate: false});
+            const browser = makeBrowser({browserName: 'browser', version: '1.0'}, {calibrate: false});
 
             Camera.prototype.captureViewportImage.returns(Promise.resolve({some: 'image'}));
 


### PR DESCRIPTION
**Rationale**: If your page contains some animations, it becomes annoying to use `.wait` before each capture to wait for the animation to finish. Additionally having animations that are triggered by scrolling currently result in inconsistent dumps when the browser scrolls the page.

**Solution**: This PR introduces a new option `screenshotDelay` which defines the time that we wait before doing any screenshot. This allows for any animation to finish before the screenshot is taken, assumed `screenshotDelay` is bigger than the longest animation time.