### PR TITLE
feat: emit async INIT event instead of async plugins load

### DIFF
--- a/doc/events.md
+++ b/doc/events.md
@@ -1,6 +1,8 @@
 # Gemini events
 
-* `AFTER_TESTS_READ` - emitted after all tests were read (during `run`, `update` or `readTests` call). The event is emitted with 1 argument `data`:
+* `INIT` - emitted before any job start (`test`, `update` or `readTests`). If handler returns a promise then job will start only after the promise will be resolved. Emitted only once no matter how many times job will be performed.
+
+* `AFTER_TESTS_READ` - emitted after all tests were read (during `test`, `update` or `readTests` call). The event is emitted with 1 argument `data`:
     * `data.suiteCollection` - suite collection with all suites parsed from test files
 
 * `UPDATE_RESULT` — emitted always during update. The event is emitted with 1 argument `result`:

--- a/lib/constants/events.js
+++ b/lib/constants/events.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports = {
+    INIT: 'init',
+
     AFTER_TESTS_READ: 'afterTestsRead',
 
     START_RUNNER: 'startRunner',

--- a/lib/gemini.js
+++ b/lib/gemini.js
@@ -46,6 +46,7 @@ module.exports = class Gemini extends PassthroughEmitter {
         this.SuiteCollection = SuiteCollection;
 
         setupLog(this.config.system.debug);
+        this._loadPlugins();
     }
 
     getScreenshotPath(suite, stateName, browserId) {
@@ -89,12 +90,16 @@ module.exports = class Gemini extends PassthroughEmitter {
     }
 
     _exec(fn) {
-        return this._loadPlugins().then(() => fn());
+        return this._init().then(() => fn());
+    }
+
+    _init() {
+        this._init = () => Promise.resolve(); // init only once
+        return this.emitAndWait(Events.INIT);
     }
 
     _loadPlugins() {
-        this._loadPlugins = () => Promise.resolve(); // load plugins only once
-        return Promise.all(pluginsLoader.load(this, this.config.system.plugins, PREFIX));
+        pluginsLoader.load(this, this.config.system.plugins, PREFIX);
     }
 
     _readTests(paths, options) {


### PR DESCRIPTION
- Откатил то, что было сделано в https://github.com/gemini-testing/gemini/pull/829, теперь плагины грузятся в конструкторе gemini, и никто их не ждет.
- Добавил асинхронное событие `INIT`, которое триггерится перед `test`, `update` или `readTests`