### PR TITLE
Add skip.in and skip.notIn to tests API

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -71,38 +71,46 @@ All methods are chainable:
   (See `tolerance`option description in [config](./config.md) documentation
   for details).
 
-* `skip([browser])` — skip all tests and nested suites for:
+* `skip.in([browser])` — skip all tests and nested suites for:
 
-  - `skip()` — all browsers;
+  - `skip.in()` — all browsers;
 
-  - `skip('id')` — browser with specified `id`;
+  - `skip.in('id')` — browser with specified `id`;
 
-  - `skip('id', comment)` — browser with specified `id` and show `comment` in the report;
+  - `skip.in('id', comment)` — browser with specified `id` and show `comment` in the report;
 
-  - `skip(/some RegExp/)` — browser with `id` which matches `/some RegExp/`;
+  - `skip.in(/some RegExp/)` — browser with `id` which matches `/some RegExp/`;
 
-  - `skip(/some RegExp/, comment)` — browser with `id` which matches `/some RegExp/` and show `comment` in the report;
+  - `skip.in(/some RegExp/, comment)` — browser with `id` which matches `/some RegExp/` and show `comment` in the report;
 
-  - `skip(['id1', /RegExp1/, ...])` — multiple browsers;
+  - `skip.in(['id1', /RegExp1/, ...])` — multiple browsers;
 
-  - `skip(['id1', /RegExp1/, ...], comment)` — multiple browsers and show `comment` in the report.
-
-  All browsers from subsequent calls to `.skip()` are added to the skip list:
+  - `skip.in(['id1', /RegExp1/, ...], comment)` — multiple browsers and show `comment` in the report.
+  
+  All browsers from subsequent calls to `.skip.in()` are added to the skip list:
 
   ```js
   suite
-      .skip('id1')
-      .skip(/RegExp1/);
+      .skip.in('id1')
+      .skip.in(/RegExp1/);
   ```
 
   is equivalent to
 
   ```js
-  suite.skip([
+  suite.skip.in([
       'id1',
       /RegExp1/
   ]);
   ```
+  
+  Method can also be called as `skip([browser])`
+  (left for backward compatibility).
+  
+* `skip.notIn([browser])` — skip all test and nested suites
+for all browsers, except for the ones in the arguments.
+Has the same principle of work as `skip.in([browser])`.
+Note that `skip.notIn()` does nothing.
 
 * `browsers([browser])` — run all tests and nested suites in specified browsers:
 

--- a/lib/tests-api/suite-builder.js
+++ b/lib/tests-api/suite-builder.js
@@ -1,14 +1,37 @@
 'use strict';
-var _ = require('lodash'),
-    State = require('../state'),
-    find = require('./find-func').find,
-    ActionsBuilder = require('./actions-builder');
+const _ = require('lodash');
+const State = require('../state');
+const find = require('./find-func').find;
+const ActionsBuilder = require('./actions-builder');
+
+// Check if selector is not a string or not an object with "every" option.
+const isNotValidSelector = (arg) => {
+    return !(_.isString(arg) || (_.isObject(arg) && _.isString(arg.every)));
+};
+
+const flattenFirstArgument = (args) => {
+    if (args.length === 1 && Array.isArray(args[0])) {
+        return args[0];
+    } else {
+        return args;
+    }
+};
+
+const isArrayOfStringsAndRegExps = (arr) => {
+    return _.every(arr, function(item) {
+        return _.isString(item) || _.isRegExp(item);
+    });
+};
+
+const createMatcher = (matcher) => {
+    return _.isRegExp(matcher) ? matcher.test.bind(matcher) : _.isEqual.bind(null, matcher);
+};
 
 module.exports = function(suite) {
-    this.setCaptureElements = function() {
-        var selectors = argumentsToArray(arguments);
+    this.setCaptureElements = (...args) => {
+        const selectors = flattenFirstArgument(args);
 
-        if (selectors.some(notString)) {
+        if (selectors.some(_.negate(_.isString))) {
             throw new TypeError('suite.captureElements accepts only strings or array of strings');
         }
 
@@ -16,7 +39,7 @@ module.exports = function(suite) {
         return this;
     };
 
-    this.before = function(hook) {
+    this.before = (hook) => {
         if (typeof hook !== 'function') {
             throw new TypeError('before hook must be a function');
         }
@@ -27,19 +50,19 @@ module.exports = function(suite) {
         return this;
     };
 
-    this.after = function(hook) {
+    this.after = (hook) => {
         if (typeof hook !== 'function') {
             throw new TypeError('after hook must be a function');
         }
 
-        var actions = [];
+        const actions = [];
         hook.call(suite.context, ActionsBuilder.create(actions), find);
         suite.afterActions = actions.concat(suite.afterActions);
 
         return this;
     };
 
-    this.setUrl = function setUrl(url) {
+    this.setUrl = (url) => {
         if (typeof url !== 'string') {
             throw new TypeError('URL must be string');
         }
@@ -47,7 +70,7 @@ module.exports = function(suite) {
         return this;
     };
 
-    this.setTolerance = function setTolerance(tolerance) {
+    this.setTolerance = (tolerance) => {
         if (typeof tolerance !== 'number') {
             throw new TypeError('tolerance must be number');
         }
@@ -55,7 +78,7 @@ module.exports = function(suite) {
         return this;
     };
 
-    this.capture = function capture(name, opts, cb) {
+    this.capture = (name, opts, cb) => {
         if (typeof name !== 'string') {
             throw new TypeError('State name should be string');
         }
@@ -77,7 +100,7 @@ module.exports = function(suite) {
                 'Choose different name');
         }
 
-        var state = new State(suite, name);
+        const state = new State(suite, name);
         cb.call(suite.context, ActionsBuilder.create(state.actions), find);
 
         if ('tolerance' in opts) {
@@ -90,8 +113,8 @@ module.exports = function(suite) {
         return this;
     };
 
-    this.ignoreElements = function ignoreElements() {
-        var selectors = argumentsToArray(arguments);
+    this.ignoreElements = (...args) => {
+        const selectors = flattenFirstArgument(args);
 
         if (selectors.some(isNotValidSelector)) {
             throw new TypeError('suite.ignoreElements accepts strings, object with property "every" as string or array of them');
@@ -100,20 +123,29 @@ module.exports = function(suite) {
         return this;
     };
 
-    this.skip = function skip(browser, comment) {
+    const saveSkipped = (browser, comment, opts = {}) => {
         if (!browser) {
-            suite.skip();
+            if (!opts.negate) {
+                suite.skip();
+            }
         } else if (_.isArray(browser)) {
-            browser.forEach(_.bind(this.skip, this, _, comment));
+            browser.forEach((b) => saveSkipped(b, comment, opts));
         } else if (_.isString(browser) || _.isRegExp(browser)) {
-            suite.skip({matches: createMatcher(browser), comment: comment});
+            const matches = opts.negate ? _.negate(createMatcher(browser)) : createMatcher(browser);
+            suite.skip({matches, comment});
         } else {
             throw new TypeError('suite.skip browser must be string or RegExp object');
         }
         return this;
     };
 
-    this.browsers = function browsers(matchers) {
+    this.skip = (browser, comment) => saveSkipped(browser, comment);
+
+    this.skip.in = this.skip;
+
+    this.skip.notIn = (browser, comment) => saveSkipped(browser, comment, {negate: true});
+
+    this.browsers = (matchers) => {
         matchers = [].concat(matchers);
         if (!isArrayOfStringsAndRegExps(matchers)) {
             throw new TypeError('suite.browsers must be string or RegExp object');
@@ -128,30 +160,3 @@ module.exports = function(suite) {
         return this;
     };
 };
-
-function notString(arg) {
-    return typeof arg !== 'string';
-}
-
-// Check if selector is not a string or not an object with "every" option.
-function isNotValidSelector(arg) {
-    return !(_.isString(arg) || (_.isObject(arg) && _.isString(arg.every)));
-}
-
-function argumentsToArray(args) {
-    if (args.length === 1 && Array.isArray(args[0])) {
-        return args[0];
-    } else {
-        return Array.prototype.slice.call(args);
-    }
-}
-
-function isArrayOfStringsAndRegExps(arr) {
-    return _.every(arr, function(item) {
-        return _.isString(item) || _.isRegExp(item);
-    });
-}
-
-function createMatcher(matcher) {
-    return _.isRegExp(matcher) ? matcher.test.bind(matcher) : _.isEqual.bind(null, matcher);
-}

--- a/test/unit/tests-api/suite-builder.js
+++ b/test/unit/tests-api/suite-builder.js
@@ -1,37 +1,37 @@
 'use strict';
 
-var SuiteBuilder = require('lib/tests-api/suite-builder'),
-    Suite = require('lib/suite'),
-    ActionsBuilder = require('lib/tests-api/actions-builder'),
-    find = require('lib/tests-api/find-func').find;
+const SuiteBuilder = require('lib/tests-api/suite-builder');
+const Suite = require('lib/suite');
+const ActionsBuilder = require('lib/tests-api/actions-builder');
+const find = require('lib/tests-api/find-func').find;
 
-describe('tests-api/suite-builder', function() {
-    var sandbox = sinon.sandbox.create(),
-        suite,
-        suiteBuilder;
+describe('tests-api/suite-builder', () => {
+    const sandbox = sinon.sandbox.create();
+    let suite;
+    let suiteBuilder;
 
-    beforeEach(function() {
+    beforeEach(() => {
         suite = Suite.create('');
         suiteBuilder = new SuiteBuilder(suite);
     });
 
-    afterEach(function() {
+    afterEach(() => {
         sandbox.restore();
     });
 
-    describe('setUrl', function() {
-        it('should throw if argument is not a string', function() {
-            assert.throws(function() {
+    describe('setUrl', () => {
+        it('should throw if argument is not a string', () => {
+            assert.throws(() => {
                 suiteBuilder.setUrl({not: 'a string'});
             }, TypeError);
         });
 
-        it('should set url property', function() {
+        it('should set url property', () => {
             suiteBuilder.setUrl('http://example.com');
             assert.equal(suite.url, 'http://example.com');
         });
 
-        it('should be chainable', function() {
+        it('should be chainable', () => {
             assert.equal(
                 suiteBuilder.setUrl(''),
                 suiteBuilder
@@ -39,19 +39,19 @@ describe('tests-api/suite-builder', function() {
         });
     });
 
-    describe('setTolerance', function() {
-        it('should throw if argument is not a string', function() {
-            assert.throws(function() {
+    describe('setTolerance', () => {
+        it('should throw if argument is not a string', () => {
+            assert.throws(() => {
                 suiteBuilder.setTolerance('so much');
             }, TypeError);
         });
 
-        it('should set tolerance passed as number', function() {
+        it('should set tolerance passed as number', () => {
             suiteBuilder.setTolerance(25);
             assert.equal(suite.tolerance, 25);
         });
 
-        it('should be chainable', function() {
+        it('should be chainable', () => {
             assert.equal(
                 suiteBuilder.setTolerance(0),
                 suiteBuilder
@@ -59,93 +59,93 @@ describe('tests-api/suite-builder', function() {
         });
     });
 
-    describe('setCaptureElements', function() {
-        it('should throw if selector is not a string', function() {
-            assert.throws(function() {
+    describe('setCaptureElements', () => {
+        it('should throw if selector is not a string', () => {
+            assert.throws(() => {
                 suiteBuilder.setCaptureElements({everything: true});
             }, TypeError);
         });
 
-        it('should throw if selector in array is not a string', function() {
-            assert.throws(function() {
+        it('should throw if selector in array is not a string', () => {
+            assert.throws(() => {
                 suiteBuilder.setCaptureElements([{everything: true}, '.selector']);
             }, TypeError);
         });
 
-        it('should set captureSelectors property', function() {
+        it('should set captureSelectors property', () => {
             suiteBuilder.setCaptureElements('.selector');
 
             assert.deepEqual(suite.captureSelectors, ['.selector']);
         });
 
-        it('should accept multiple arguments', function() {
+        it('should accept multiple arguments', () => {
             suiteBuilder.setCaptureElements('.selector1', '.selector2');
             assert.deepEqual(suite.captureSelectors, ['.selector1', '.selector2']);
         });
 
-        it('should accept array', function() {
+        it('should accept array', () => {
             suiteBuilder.setCaptureElements(['.selector1', '.selector2']);
 
             assert.deepEqual(suite.captureSelectors, ['.selector1', '.selector2']);
         });
     });
 
-    describe('ignoreElements', function() {
-        it('should throw if selector is a null', function() {
-            assert.throws(function() {
+    describe('ignoreElements', () => {
+        it('should throw if selector is a null', () => {
+            assert.throws(() => {
                 suiteBuilder.ignoreElements(null);
             }, TypeError);
         });
 
-        it('should throw if selector is object without property "every"', function() {
-            assert.throws(function() {
+        it('should throw if selector is object without property "every"', () => {
+            assert.throws(() => {
                 suiteBuilder.ignoreElements({});
             }, TypeError);
         });
 
-        it('should throw if selector is an object with property "every" that not a string', function() {
-            assert.throws(function() {
+        it('should throw if selector is an object with property "every" that not a string', () => {
+            assert.throws(() => {
                 suiteBuilder.ignoreElements({every: null});
             }, TypeError);
         });
 
-        it('should throw if one of selectors in array has wrong type', function() {
-            assert.throws(function() {
+        it('should throw if one of selectors in array has wrong type', () => {
+            assert.throws(() => {
                 suiteBuilder.ignoreElements([{every: true}, '.selector']);
             }, TypeError);
         });
 
-        it('should set ignoreSelectors property as string', function() {
+        it('should set ignoreSelectors property as string', () => {
             suiteBuilder.ignoreElements('.selector');
 
             assert.deepEqual(suite.ignoreSelectors, ['.selector']);
         });
 
-        it('should set ignoreSelectors property as object with property "every"', function() {
+        it('should set ignoreSelectors property as object with property "every"', () => {
             suiteBuilder.ignoreElements({every: '.selector'});
 
             assert.deepEqual(suite.ignoreSelectors, [{every: '.selector'}]);
         });
 
-        it('should accept multiple arguments', function() {
+        it('should accept multiple arguments', () => {
             suiteBuilder.ignoreElements('.selector1', {every: '.selector2'});
 
             assert.deepEqual(suite.ignoreSelectors, ['.selector1', {every: '.selector2'}]);
         });
 
-        it('should accept array', function() {
+        it('should accept array', () => {
             suiteBuilder.ignoreElements(['.selector1', {every: '.selector2'}]);
 
             assert.deepEqual(suite.ignoreSelectors, ['.selector1', {every: '.selector2'}]);
         });
     });
 
-    describe('before', function() {
-        beforeEach(function() {
+    describe('before', () => {
+        beforeEach(() => {
             sandbox.stub(ActionsBuilder, 'create').returns(new ActionsBuilder());
         });
 
-        it('should call before hook with actions builder and find', function() {
+        it('should call before hook with actions builder and find', () => {
             var hook = sinon.stub();
 
             suiteBuilder.before(hook);
@@ -154,7 +154,7 @@ describe('tests-api/suite-builder', function() {
             assert.calledWith(hook, sinon.match.instanceOf(ActionsBuilder), find);
         });
 
-        it('should call before hook and set beforeActions property', function() {
+        it('should call before hook and set beforeActions property', () => {
             ActionsBuilder.create.returnsArg(0);
 
             suiteBuilder.before(function(actions) {
@@ -164,7 +164,7 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual([1, 2, 3], suite.beforeActions);
         });
 
-        it('should call before hook with suite context', function() {
+        it('should call before hook with suite context', () => {
             var hook = sinon.stub();
 
             suiteBuilder.before(hook);
@@ -175,7 +175,7 @@ describe('tests-api/suite-builder', function() {
             );
         });
 
-        it('should prepend suite beforeActions with parent beforeActions', function() {
+        it('should prepend suite beforeActions with parent beforeActions', () => {
             var parent = Suite.create('parent'),
                 suite = Suite.create('suite', parent);
 
@@ -188,7 +188,7 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual([1, 2, 3, 4, 5], suite.beforeActions);
         });
 
-        it('should not affect parent beforeActions property', function() {
+        it('should not affect parent beforeActions property', () => {
             var parent = Suite.create('parent'),
                 suite = Suite.create('suite', parent);
 
@@ -202,13 +202,13 @@ describe('tests-api/suite-builder', function() {
         });
     });
 
-    describe('after', function() {
-        beforeEach(function() {
+    describe('after', () => {
+        beforeEach(() => {
             sandbox.stub(ActionsBuilder, 'create').returns(new ActionsBuilder());
         });
 
-        it('should call after hook with actions builder and find', function() {
-            var hook = sinon.stub();
+        it('should call after hook with actions builder and find', () => {
+            const hook = sinon.stub();
 
             suiteBuilder.after(hook);
 
@@ -216,7 +216,7 @@ describe('tests-api/suite-builder', function() {
             assert.calledWith(hook, sinon.match.instanceOf(ActionsBuilder), find);
         });
 
-        it('should call after hook and set afterActions property', function() {
+        it('should call after hook and set afterActions property', () => {
             ActionsBuilder.create.returnsArg(0);
 
             suiteBuilder.after(function(actions) {
@@ -226,8 +226,8 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual([1, 2, 3], suite.afterActions);
         });
 
-        it('should call after hook with suite context', function() {
-            var hook = sinon.stub();
+        it('should call after hook with suite context', () => {
+            const hook = sinon.stub();
 
             suiteBuilder.after(hook);
 
@@ -237,9 +237,9 @@ describe('tests-api/suite-builder', function() {
             );
         });
 
-        it('should append parent afterActions to suite afterActions', function() {
-            var parent = Suite.create('parent'),
-                suite = Suite.create('suite', parent);
+        it('should append parent afterActions to suite afterActions', () => {
+            const parent = Suite.create('parent');
+            const suite = Suite.create('suite', parent);
 
             parent.afterActions = [4, 5];
             ActionsBuilder.create.returnsArg(0);
@@ -250,9 +250,9 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual([1, 2, 3, 4, 5], suite.afterActions);
         });
 
-        it('should not affect parent afterActions property', function() {
-            var parent = Suite.create('parent'),
-                suite = Suite.create('suite', parent);
+        it('should not affect parent afterActions property', () => {
+            const parent = Suite.create('parent');
+            const suite = Suite.create('suite', parent);
 
             parent.afterActions = [4, 5];
             ActionsBuilder.create.returnsArg(0);
@@ -264,44 +264,44 @@ describe('tests-api/suite-builder', function() {
         });
     });
 
-    describe('capture', function() {
-        beforeEach(function() {
+    describe('capture', () => {
+        beforeEach(() => {
             suiteBuilder
                 .setUrl('/path')
                 .setCaptureElements('.element');
         });
 
-        it('should throw if first argument is not passed', function() {
-            assert.throws(function() {
+        it('should throw if first argument is not passed', () => {
+            assert.throws(() => {
                 suiteBuilder.capture({not: 'a string'});
             }, TypeError);
         });
 
-        it('should throw if second argument is not a function', function() {
-            assert.throws(function() {
+        it('should throw if second argument is not a function', () => {
+            assert.throws(() => {
                 suiteBuilder.capture('state', 'make me a sandwich');
             }, TypeError);
         });
 
-        it('should not throw if second argument is absent', function() {
-            assert.doesNotThrow(function() {
+        it('should not throw if second argument is absent', () => {
+            assert.doesNotThrow(() => {
                 suiteBuilder.capture('state');
             });
         });
 
-        it('should create named state', function() {
+        it('should create named state', () => {
             suiteBuilder.capture('state');
             assert.equal(suite.states[0].name, 'state');
         });
 
-        it('should throw if state with such name already exists', function() {
-            assert.throws(function() {
+        it('should throw if state with such name already exists', () => {
+            assert.throws(() => {
                 suiteBuilder.capture('state');
                 suiteBuilder.capture('state');
             });
         });
 
-        it('should allow to have multiple states of different names', function() {
+        it('should allow to have multiple states of different names', () => {
             suiteBuilder
                 .capture('state 1')
                 .capture('state 2');
@@ -310,13 +310,13 @@ describe('tests-api/suite-builder', function() {
             assert.equal(suite.states[1].name, 'state 2');
         });
 
-        it('should make new state reference the suite', function() {
+        it('should make new state reference the suite', () => {
             suiteBuilder.capture('state');
             assert.equal(suite.states[0].suite, suite);
         });
 
-        it('should call passed callback with actions builder and find', function() {
-            var cb = sinon.stub();
+        it('should call passed callback with actions builder and find', () => {
+            const cb = sinon.stub();
 
             suiteBuilder.capture('state', cb);
 
@@ -324,8 +324,8 @@ describe('tests-api/suite-builder', function() {
             assert.calledWith(cb, sinon.match.instanceOf(ActionsBuilder), find);
         });
 
-        it('should call passed callback with suite context', function() {
-            var cb = sinon.stub();
+        it('should call passed callback with suite context', () => {
+            const cb = sinon.stub();
 
             suiteBuilder.capture('state', cb);
 
@@ -335,7 +335,7 @@ describe('tests-api/suite-builder', function() {
             );
         });
 
-        it('should set `actions` property', function() {
+        it('should set `actions` property', () => {
             sandbox.stub(ActionsBuilder, 'create').returnsArg(0);
 
             suiteBuilder.capture('state', function(actions) {
@@ -345,63 +345,63 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual([1, 2, 3], suite.states[0].actions);
         });
 
-        it('should allow to set tolerance', function() {
-            suiteBuilder.capture('state', {tolerance: 25}, function() {});
+        it('should allow to set tolerance', () => {
+            suiteBuilder.capture('state', {tolerance: 25}, () => {});
             assert.equal(suite.states[0].tolerance, 25);
         });
 
-        it('should throw if tolerance is not a number', function() {
-            assert.throws(function() {
-                suiteBuilder.capture('state', {tolerance: 'so much'}, function() {});
+        it('should throw if tolerance is not a number', () => {
+            assert.throws(() => {
+                suiteBuilder.capture('state', {tolerance: 'so much'}, () => {});
             }, TypeError);
         });
 
-        it('should be chainable', function() {
+        it('should be chainable', () => {
             assert.equal(suiteBuilder.capture('state'), suiteBuilder);
         });
     });
 
-    describe('skip', function() {
-        it('should throw if argument is not a string nor RegExp', function() {
-            assert.throws(function() {
-                suiteBuilder.skip(123);
+    describe('skip.in', () => {
+        it('should throw if argument is not a string nor RegExp', () => {
+            assert.throws(() => {
+                suiteBuilder.skip.in(123);
             }, TypeError);
         });
 
-        it('should throw if argument is array with non-string or non-RegExp', function() {
-            assert.throws(function() {
-                suiteBuilder.skip([123]);
+        it('should throw if argument is array with non-string or non-RegExp', () => {
+            assert.throws(() => {
+                suiteBuilder.skip.in([123]);
             }, TypeError);
         });
 
-        it('should throw if argument is an object', function() {
-            assert.throws(function() {
-                suiteBuilder.skip({browserName: 'name', version: '123', id: 'browser'});
+        it('should throw if argument is an object', () => {
+            assert.throws(() => {
+                suiteBuilder.skip.in({browserName: 'name', version: '123', id: 'browser'});
             }, Error);
         });
 
-        it('should mark suite as skipped', function() {
-            suiteBuilder.skip();
+        it('should mark suite as skipped', () => {
+            suiteBuilder.skip.in();
             assert.isTrue(suite.skipped);
         });
 
-        it('should accept skipped browser string id', function() {
-            suiteBuilder.skip('opera');
+        it('should accept skipped browser string id', () => {
+            suiteBuilder.skip.in('opera');
 
             assert.equal(suite.skipped.length, 1);
             assert.isTrue(suite.skipped[0].matches('opera'));
             assert.isFalse(suite.skipped[0].matches('firefox'));
         });
 
-        it('should accept skipped browser RegExp', function() {
-            suiteBuilder.skip(/ie1.*/);
+        it('should accept skipped browser RegExp', () => {
+            suiteBuilder.skip.in(/ie1.*/);
 
             assert.isTrue(suite.skipped[0].matches('ie11'));
             assert.isFalse(suite.skipped[0].matches('ie8'));
         });
 
-        it('should accept array of string ids and RegExp\'s', function() {
-            suiteBuilder.skip([
+        it('should accept array of string ids and RegExp\'s', () => {
+            suiteBuilder.skip.in([
                 'ie11',
                 /firefox/
             ]);
@@ -411,34 +411,94 @@ describe('tests-api/suite-builder', function() {
         });
     });
 
-    describe('browsers', function() {
-        var rootSuite;
+    describe('skip.notIn', () => {
+        it('should throw if argument is not a string nor RegExp', () => {
+            assert.throws(() => {
+                suiteBuilder.skip.notIn(123);
+            }, TypeError);
+        });
 
-        beforeEach(function() {
+        it('should throw if argument is array with non-string or non-RegExp', () => {
+            assert.throws(() => {
+                suiteBuilder.skip.notIn([123]);
+            }, TypeError);
+        });
+
+        it('should throw if argument is an object', () => {
+            assert.throws(() => {
+                suiteBuilder.skip.notIn({browserName: 'name', version: '123', id: 'browser'});
+            }, Error);
+        });
+
+        it('should not mark suite as skipped', () => {
+            suiteBuilder.skip.notIn();
+            assert.isFalse(suite.skipped);
+        });
+
+        it('should skip all browsers except string id', () => {
+            suiteBuilder.skip.notIn('opera');
+
+            assert.equal(suite.skipped.length, 1);
+            assert.isFalse(suite.skipped[0].matches('opera'));
+            assert.isTrue(suite.skipped[0].matches('firefox'));
+        });
+
+        it('should skip all browsers except RegExp', () => {
+            suiteBuilder.skip.notIn(/ie1.*/);
+
+            assert.isFalse(suite.skipped[0].matches('ie11'));
+            assert.isTrue(suite.skipped[0].matches('ie8'));
+        });
+
+        it('should accept array of string ids and RegExp\'s', () => {
+            suiteBuilder.skip.notIn([
+                'ie11',
+                /firefox/
+            ]);
+
+            assert.isFalse(suite.skipped[0].matches('ie11'));
+            assert.isFalse(suite.skipped[1].matches('firefox33'));
+        });
+    });
+
+    describe('skip methods combined', () => {
+        it('should skip all browsers if skip.in and skip.notIn arguments are same', () => {
+            suiteBuilder.skip.in('chrome');
+            suiteBuilder.skip.notIn('chrome');
+
+            assert.isTrue(suite.shouldSkip('chrome'));
+            assert.isTrue(suite.shouldSkip('firefox'));
+        });
+    });
+
+    describe('browsers', () => {
+        let rootSuite;
+
+        beforeEach(() => {
             rootSuite = Suite.create('');
             suite = Suite.create('some-suite', rootSuite);
             suiteBuilder = new SuiteBuilder(suite);
         });
 
-        it('should throw without an argument', function() {
-            assert.throws(function() {
+        it('should throw without an argument', () => {
+            assert.throws(() => {
                 suiteBuilder.browsers();
             }, /string or RegExp/);
         });
 
-        it('should throw if an argument is not a string or RegExp', function() {
-            assert.throws(function() {
+        it('should throw if an argument is not a string or RegExp', () => {
+            assert.throws(() => {
                 suiteBuilder.browsers(123);
             }, /string or RegExp/);
         });
 
-        it('should throw if an argument is an array of non-strings or non-RegExps', function() {
-            assert.throws(function() {
+        it('should throw if an argument is an array of non-strings or non-RegExps', () => {
+            assert.throws(() => {
                 suiteBuilder.browsers([123]);
             }, /string or RegExp/);
         });
 
-        it('should filter suite browsers by a string', function() {
+        it('should filter suite browsers by a string', () => {
             rootSuite.browsers = ['ie8', 'ie9', 'chrome'];
 
             suiteBuilder.browsers('chrome');
@@ -446,7 +506,7 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual(suite.browsers, ['chrome']);
         });
 
-        it('should filter suite browsers by a RegExp', function() {
+        it('should filter suite browsers by a RegExp', () => {
             rootSuite.browsers = ['ie8', 'ie9', 'chrome'];
 
             suiteBuilder.browsers(/ie.+/);
@@ -454,7 +514,7 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual(suite.browsers, ['ie8', 'ie9']);
         });
 
-        it('should filter suite browsers by an array of strings', function() {
+        it('should filter suite browsers by an array of strings', () => {
             rootSuite.browsers = ['ie8', 'ie9', 'chrome'];
 
             suiteBuilder.browsers(['chrome']);
@@ -462,7 +522,7 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual(suite.browsers, ['chrome']);
         });
 
-        it('should filter suite browsers by an array of RegExps', function() {
+        it('should filter suite browsers by an array of RegExps', () => {
             rootSuite.browsers = ['ie8', 'ie9', 'chrome'];
 
             suiteBuilder.browsers([/ie.+/]);
@@ -470,7 +530,7 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual(suite.browsers, ['ie8', 'ie9']);
         });
 
-        it('should filter suite browsers by an array of strings and RegExps', function() {
+        it('should filter suite browsers by an array of strings and RegExps', () => {
             rootSuite.browsers = ['ie8', 'ie9', 'opera', 'chrome'];
 
             suiteBuilder.browsers([/ie.+/, 'chrome']);
@@ -478,7 +538,7 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual(suite.browsers, ['ie8', 'ie9', 'chrome']);
         });
 
-        it('should not set a browser for a suite if it is not specified in a root one', function() {
+        it('should not set a browser for a suite if it is not specified in a root one', () => {
             rootSuite.browsers = ['opera'];
 
             suiteBuilder.browsers('chrome');
@@ -486,13 +546,13 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual(suite.browsers, []);
         });
 
-        it('should be chainable', function() {
+        it('should be chainable', () => {
             assert.equal(suiteBuilder.browsers([]), suiteBuilder);
         });
 
-        it('should filter browsers in all children suites', function() {
-            var firstChild = Suite.create('firstChild', suite),
-                secondChild = Suite.create('secondChild', suite);
+        it('should filter browsers in all children suites', () => {
+            const firstChild = Suite.create('firstChild', suite);
+            const secondChild = Suite.create('secondChild', suite);
 
             rootSuite.browsers = ['ie8', 'ie9', 'opera', 'chrome'];
 
@@ -505,8 +565,8 @@ describe('tests-api/suite-builder', function() {
             assert.deepEqual(secondChild.browsers, ['chrome']);
         });
 
-        it('should pass filtered browsers from a parent suite to a child one', function() {
-            var childSuite = Suite.create('child', suite);
+        it('should pass filtered browsers from a parent suite to a child one', () => {
+            const childSuite = Suite.create('child', suite);
 
             rootSuite.browsers = ['ie8', 'ie9', 'opera', 'chrome'];
 


### PR DESCRIPTION
```js
gemini.suite('yandex-page2', function(suite) {
    suite.setUrl('/')
        .setCaptureElements('body');

    gemini.suite('yandex-logo', function (suite) {
        suite.setUrl('/')
            .setCaptureElements('.home-logo__default')
            .skip.in(['chrome', 'firefox'], 'using skip.in')
            .capture('plain');
    });

    gemini.suite('yandex-logo-again', function (suite) {
        suite.setUrl('/')
            .setCaptureElements('.home-logo__default')
            .skip.notIn(/opera/, 'using skip.notIn')
            .capture('plain');
    });
});
```

Итог:
<img width="343" alt="gemini report 2018-01-18 18-12-20" src="https://user-images.githubusercontent.com/25789153/35104876-d8c06292-fc72-11e7-9075-360d4e5853fc.png">
