### PR TITLE
Fix ignoreElements outside viewport

### DIFF
--- a/lib/capture-session/viewport.js
+++ b/lib/capture-session/viewport.js
@@ -20,13 +20,26 @@ module.exports = class Viewport {
     }
 
     ignoreAreas(areas) {
-        areas.forEach((area) => {
-            this._image.clear(this._transformToViewportOrigin(area), {scaleFactor: this._pixelRatio});
-        });
+        _(areas)
+            .map((area) => this._getIntersectionWithViewport(area))
+            .compact()
+            .forEach((area) => this._image.clear(this._transformToViewportOrigin(area), {scaleFactor: this._pixelRatio}));
     }
 
     crop(captureArea) {
         return this._image.crop(this._transformToViewportOrigin(captureArea), {scaleFactor: this._pixelRatio});
+    }
+
+    _getIntersectionWithViewport(area) {
+        const top = Math.max(this._viewport.top, area.top);
+        const bottom = Math.min(getAreaBottom(this._viewport), getAreaBottom(area));
+        const left = Math.max(this._viewport.left, area.left);
+        const right = Math.min(getAreaRight(this._viewport), getAreaRight(area));
+
+        if (left >= right || top >= bottom) {
+            return null;
+        }
+        return {top, left, width: right - left, height: bottom - top};
     }
 
     _transformToViewportOrigin(area) {
@@ -59,3 +72,11 @@ module.exports = class Viewport {
         return captureArea.height - this._viewport.height;
     }
 };
+
+function getAreaBottom(area) {
+    return area.top + area.height;
+}
+
+function getAreaRight(area) {
+    return area.left + area.width;
+}

--- a/test/unit/capture-session/viewport.js
+++ b/test/unit/capture-session/viewport.js
@@ -54,19 +54,60 @@ describe('Viewport', () => {
         beforeEach(() => image = sinon.createStubInstance(Image));
 
         it('should ignore passed areas', () => {
-            const viewport = createViewport({image, pixelRatio: 1});
+            const viewport = createViewport({coords: {top: 0, left: 0, width: 20, height: 20}, image, pixelRatio: 1});
 
-            viewport.ignoreAreas([{top: 1, left: 1}]);
+            viewport.ignoreAreas([{top: 1, left: 1, width: 10, height: 10}]);
 
-            assert.calledWith(image.clear, {top: 1, left: 1}, {scaleFactor: 1});
+            assert.calledWith(image.clear, {top: 1, left: 1, width: 10, height: 10}, {scaleFactor: 1});
         });
 
         it('should transform area coordinates to a viewport origin', () => {
-            const viewport = createViewport({coords: {top: 1, left: 1}, image});
+            const viewport = createViewport({coords: {top: 1, left: 1, width: 20, height: 20}, image});
 
-            viewport.ignoreAreas([{top: 1, left: 1}]);
+            viewport.ignoreAreas([{top: 1, left: 1, width: 10, height: 10}]);
 
-            assert.calledWith(image.clear, {top: 0, left: 0});
+            assert.calledWith(image.clear, {top: 0, left: 0, width: 10, height: 10});
+        });
+
+        it('should crop area size to a viewport origin (inside)', () => {
+            const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image});
+
+            const area = {top: 10, left: 5, width: 20, height: 5};
+            viewport.ignoreAreas([area]);
+
+            assert.calledWith(image.clear, area);
+        });
+
+        it('should crop area size to a viewport origin (bottom right)', () => {
+            const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image});
+
+            viewport.ignoreAreas([{top: 10, left: 5, width: 30, height: 5}]);
+
+            assert.calledWith(image.clear, {top: 10, left: 5, width: 25, height: 5});
+        });
+
+        it('should crop area size to a viewport origin (top left)', () => {
+            const viewport = createViewport({coords: {top: 20, left: 15, width: 30, height: 20}, image});
+
+            viewport.ignoreAreas([{top: 10, left: 5, width: 20, height: 20}]);
+
+            assert.calledWith(image.clear, {top: 0, left: 0, width: 10, height: 10});
+        });
+
+        it('should not clear image if area is outside of viewport (bottom right)', () => {
+            const viewport = createViewport({coords: {top: 0, left: 0, width: 30, height: 20}, image});
+
+            viewport.ignoreAreas([{top: 21, left: 31, width: 30, height: 5}]);
+
+            assert.notCalled(image.clear);
+        });
+
+        it('should not clear image if area is outside of viewport (top left)', () => {
+            const viewport = createViewport({coords: {top: 21, left: 31, width: 30, height: 20}, image});
+
+            viewport.ignoreAreas([{top: 0, left: 0, width: 30, height: 20}]);
+
+            assert.notCalled(image.clear);
         });
     });
 


### PR DESCRIPTION
Для каждого игнорируемого элемента строится пересечение его области с viewport'ом. Таким образом, закрашивается только та часть элемента, что входит в зону видимости.