### PR TITLE
Add captureViewport option in tests-api

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -105,6 +105,10 @@ All methods are chainable:
 
     See `tolerance`option description in [config](./config.md)
     documentation for details.
+    
+* `captureViewport(stateName, [options], callback(actions, find))` –
+same as `capture`, except this method ignores `setCaptureElements`
+and takes screenshot of whole visible viewport.
 
 * `before(callback(actions, find))` — use this function to execute some code
   before the first state. The arguments of a callback are the same as for

--- a/lib/state.js
+++ b/lib/state.js
@@ -7,13 +7,14 @@ module.exports = class State {
         this.suite = suite;
         this.name = name;
         this._ownTolerance = null;
+        this._viewportOnly = false;
         this.actions = [];
         this.browsers = _.clone(suite.browsers);
     }
 
     clone() {
         const clonedState = new State(this.suite, this.name);
-        ['_ownTolerance', 'actions'].forEach((prop) => {
+        ['_ownTolerance', 'actions', '_viewportOnly'].forEach((prop) => {
             clonedState[prop] = _.clone(this[prop]);
         });
 
@@ -33,7 +34,7 @@ module.exports = class State {
     }
 
     get captureSelectors() {
-        return this.suite.captureSelectors;
+        return this._viewportOnly ? null : this.suite.captureSelectors;
     }
 
     get ignoreSelectors() {
@@ -46,5 +47,13 @@ module.exports = class State {
 
     set tolerance(value) {
         this._ownTolerance = value;
+    }
+
+    get viewportOnly() {
+        return this._viewportOnly;
+    }
+
+    set viewportOnly(value) {
+        this._viewportOnly = value;
     }
 };

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -115,6 +115,10 @@ module.exports = class Suite {
         return this._states.length > 0;
     }
 
+    get hasCaptureSelectorsStates() {
+        return _.some(this._states, ['viewportOnly', false]);
+    }
+
     get isRoot() {
         return !this.parent;
     }

--- a/lib/tests-api/index.js
+++ b/lib/tests-api/index.js
@@ -46,7 +46,7 @@ module.exports = (suite, browsers, file, config) => {
                     '" suite or one of its parents');
             }
 
-            if (!suite.captureSelectors) {
+            if (suite.hasCaptureSelectorsStates && !suite.captureSelectors) {
                 throw new Error('Capture region is required to capture screenshots. ' +
                     'Call suite.setCaptureElements(<CSS SELECTORS>) on "' + suite.name +
                     '" suite or one of its parents');

--- a/lib/tests-api/suite-builder.js
+++ b/lib/tests-api/suite-builder.js
@@ -63,40 +63,6 @@ module.exports = class SuiteBuilder {
         return this;
     }
 
-    capture(name, opts, cb) {
-        if (!_.isString(name)) {
-            throw new TypeError('State name should be string');
-        }
-
-        if (!cb) {
-            cb = opts;
-            opts = null;
-        }
-
-        cb = cb || _.noop;
-        opts = opts || {};
-
-        if (!_.isFunction(cb)) {
-            throw new TypeError('Second argument of suite.capture must be a function');
-        }
-
-        if (this._suite.hasStateNamed(name)) {
-            throw new Error(`State "${name}" already exists in suite "${this._suite.name}". Choose different name`);
-        }
-
-        const state = new State(this._suite, name);
-        cb.call(this._suite.context, ActionsBuilder.create(state.actions), find);
-
-        if ('tolerance' in opts) {
-            if (!_.isNumber(opts.tolerance)) {
-                throw new TypeError('Tolerance should be number');
-            }
-            state.tolerance = opts.tolerance;
-        }
-        this._suite.addState(state);
-        return this;
-    }
-
     ignoreElements(...selectors) {
         selectors = _.flatten(selectors);
 
@@ -113,6 +79,58 @@ module.exports = class SuiteBuilder {
         const onlyBuilder = OnlyBuilder.create(this._suite);
 
         _.extend(this, skipBuilder.buildAPI(this), onlyBuilder.buildAPI(this));
+    }
+
+    capture(name, opts, cb) {
+        ({name, opts, cb} = this._rearrangeCaptureArgs(name, opts, cb));
+        opts = _.assign({}, opts, {viewportOnly: false});
+        return this._processCapture(name, opts, cb);
+    }
+
+    captureViewport(name, opts, cb) {
+        ({name, opts, cb} = this._rearrangeCaptureArgs(name, opts, cb));
+        opts = _.assign({}, opts, {viewportOnly: true});
+        return this._processCapture(name, opts, cb);
+    }
+
+    _rearrangeCaptureArgs(name, opts, cb) {
+        if (!cb) {
+            cb = opts;
+            opts = null;
+        }
+
+        cb = cb || _.noop;
+        opts = opts || {};
+
+        return {name, opts, cb};
+    }
+
+    _processCapture(name, opts, cb) {
+        if (!_.isString(name)) {
+            throw new TypeError('State name should be string');
+        }
+
+        if (!_.isFunction(cb)) {
+            throw new TypeError('Second argument of suite.capture must be a function');
+        }
+
+        if (this._suite.hasStateNamed(name)) {
+            throw new Error(`State "${name}" already exists in suite "${this._suite.name}". Choose different name`);
+        }
+
+        const state = new State(this._suite, name);
+        cb.call(this._suite.context, ActionsBuilder.create(state.actions), find);
+
+        if (_.has(opts, 'tolerance')) {
+            if (!_.isNumber(opts.tolerance)) {
+                throw new TypeError('Tolerance should be number');
+            }
+            state.tolerance = opts.tolerance;
+        }
+        state.viewportOnly = opts.viewportOnly;
+
+        this._suite.addState(state);
+        return this;
     }
 
 };

--- a/test/unit/state.js
+++ b/test/unit/state.js
@@ -36,6 +36,32 @@ describe('state methods', () => {
         });
     });
 
+    describe('viewportOnly', () => {
+        let suite, state;
+
+        beforeEach(() => {
+            suite = util.makeSuiteStub();
+            state = new State(suite);
+        });
+
+        it('viewportOnly should be false by default', () => {
+            assert.isFalse(state.viewportOnly);
+        });
+
+        it('should set viewportOnly for the current state', () => {
+            state.viewportOnly = true;
+
+            assert.isTrue(state.viewportOnly);
+        });
+
+        it('should return null for captureSelectors if viewportOnly is true', () => {
+            suite.captureSelectors = 'selector';
+            state.viewportOnly = true;
+
+            assert.isNull(state.captureSelectors);
+        });
+    });
+
     it('should return state fullName', () => {
         const suite = util.makeSuiteStub({name: 'suite-name'});
         const state = new State(suite, 'plain');
@@ -78,6 +104,15 @@ describe('state methods', () => {
             const clonedState = state.clone();
 
             assert.equal(clonedState.tolerance, 100);
+        });
+
+        it('should clone viewportOnly from the origin state', () => {
+            const state = new State({});
+            state.viewportOnly = true;
+
+            const clonedState = state.clone();
+
+            assert.isTrue(clonedState.viewportOnly);
         });
     });
 });

--- a/test/unit/suite.js
+++ b/test/unit/suite.js
@@ -147,6 +147,32 @@ describe('suite', () => {
         });
     });
 
+    describe('hasCaptureSelectorsStates', () => {
+        let suite;
+
+        beforeEach(() => {
+            suite = createSuite('suite');
+        });
+
+        it('should be false if there is no states', () => {
+            assert.isFalse(suite.hasCaptureSelectorsStates);
+        });
+
+        it('should be false if all states are created to capture viewport', () => {
+            suite.addState({name: 'state1', viewportOnly: true});
+            suite.addState({name: 'state2', viewportOnly: true});
+
+            assert.isFalse(suite.hasCaptureSelectorsStates);
+        });
+
+        it('should be true if some states are created to capture selectors', () => {
+            suite.addState({name: 'state1', viewportOnly: true});
+            suite.addState({name: 'state2', viewportOnly: false});
+
+            assert.isTrue(suite.hasCaptureSelectorsStates);
+        });
+    });
+
     describe('isRoot', () => {
         it('should be true for root suites', () => {
             const suite = createSuite('suite');

--- a/test/unit/tests-api/index.js
+++ b/test/unit/tests-api/index.js
@@ -89,7 +89,7 @@ describe('tests-api', () => {
             });
         });
 
-        it('should throw when suite has no states nor URL', () => {
+        it('should not throw when suite has neither states nor URL', () => {
             assert.doesNotThrow(() => {
                 gemini.suite('first', (suite) => {
                     suite.setCaptureElements('.element');
@@ -118,7 +118,7 @@ describe('tests-api', () => {
             });
         });
 
-        it('should not throw if suite has no states nor captureSelectors', () => {
+        it('should not throw if suite has neither states nor captureSelectors', () => {
             assert.doesNotThrow(() => {
                 gemini.suite('first', (suite) => {
                     suite.setUrl('/url');
@@ -134,6 +134,15 @@ describe('tests-api', () => {
                         suite.setUrl('/url')
                              .capture('plain');
                     });
+                });
+            });
+        });
+
+        it('should not throw if suite has states and does not has captureSelectors but captureViewport is used', () => {
+            assert.doesNotThrow(() => {
+                gemini.suite('first', (suite) => {
+                    suite.setUrl('/url')
+                        .captureViewport('plain');
                 });
             });
         });


### PR DESCRIPTION
```js
compositeImage: true,
calibrate: true,
```
```js
gemini.suite('test-popup', (suite) => {
    suite.setUrl('test_popup.html')
        .browsers(['chrome'])
        .setCaptureElements('div', 'div~div')
        .ignoreElements('div')
        .captureViewport('viewport')
        .capture('div');
});
```

![chrome ref](https://user-images.githubusercontent.com/25789153/35920182-d40ef7f6-0c1f-11e8-92aa-e32299b827d2.png)

Исправляемые модули `suite-builder` не переводил на ES6, так как я это сделал уже в
[другом pr](https://github.com/gemini-testing/gemini/pull/867).

Пришлось вносить изменения в [клиентские скрипты](https://github.com/gemini-testing/gemini-core/pull/26), так как получить `ignoreElements` можно только там. Снятие скриншота вьюпорта приравнивается к действию `captureArea := viewport`.
