### PR TITLE
feat(config): introduce shouldRerty config option

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -226,6 +226,11 @@ Settings list:
   specified, the fallen tests will not be relaunched (by default it's 0).
 
   Note that the same test never be performed in the same browser session.
+  
+* `shouldRetry` — function which defines whether to make a retry. Should returns `Boolean` value. First argument is `data` which is the result of the test run, it's an Object with following fields:
+    * `attempt {Number}` number of retries performed for the test
+    * `retriesLeft {Number}` number of retries left
+    * `[equal] {Boolean}` notice that if the test fails with critical error equal can be absent
 
 * `screenshotMode` — image capture mode. There are 3 allowed values for this option:
     * `auto` (default). Mode will be obtained automatically.

--- a/lib/runner/suite-runner/insistent-suite-runner.js
+++ b/lib/runner/suite-runner/insistent-suite-runner.js
@@ -72,15 +72,27 @@ module.exports = class InsistentSuiteRunner extends SuiteRunner {
         this._statesToRetry.forEach((state) => collection.enable(suite, {state, browser}));
     }
 
-    _submitForRetry(e) {
-        const retriesLeft = this._config.retry - this._retriesPerformed;
-        if (retriesLeft <= 0) {
+    _shouldRetry(data) {
+        if (typeof this._config.shouldRetry === 'function') {
+            return this._config.shouldRetry(data);
+        }
+
+        return data.retriesLeft > 0;
+    }
+
+    _submitForRetry(data) {
+        Object.assign(data, {
+            attempt: this._retriesPerformed,
+            retriesLeft: this._config.retry - this._retriesPerformed
+        });
+
+        if (!this._shouldRetry(data)) {
             return false;
         }
 
-        this._statesToRetry = this._statesToRetry.concat(e.state.name);
+        this._statesToRetry = this._statesToRetry.concat(data.state.name);
 
-        this._emit(Events.RETRY, _.extend(e, {attempt: this._retriesPerformed, retriesLeft}));
+        this._emit(Events.RETRY, data);
         return true;
     }
 };


### PR DESCRIPTION
Config should provide to users option to set custom rule whether test retry
needed or not. 

Related to:
* FEI-8660
* https://github.com/gemini-testing/retry-limiter/pull/6