### PR TITLE
Suite clone does not clone fullUrl fixed

### DIFF
--- a/lib/runner/browser-runner/index.js
+++ b/lib/runner/browser-runner/index.js
@@ -30,6 +30,7 @@ module.exports = class BrowserRunner extends Runner {
             .map((suite) => {
                 if (suite.hasOwnProperty('url')) {
                     Object.defineProperty(suite, 'fullUrl', {
+                        enumerable: true,
                         get: () => this._mkFullUrl(suite.url)
                     });
                 }

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -84,7 +84,8 @@ module.exports = class Suite {
         const clonedSuite = Suite.create(this.name, this.parent);
 
         _.forOwn(this, (value, key) => {
-            clonedSuite[key] = _.clone(value);
+            let desc = Object.getOwnPropertyDescriptor(this, key);
+            Object.defineProperty(clonedSuite, key, _.cloneDeep(desc));
         });
 
         this.children.forEach((child) => clonedSuite.addChild(child.clone()));

--- a/test/unit/suite.js
+++ b/test/unit/suite.js
@@ -342,9 +342,26 @@ describe('suite', () => {
 
         it('should return cloned suite', () => {
             const suite = createSuite('origin');
+            suite.browsers = ['bro1', 'bro2'];
             const clonedSuite = suite.clone();
 
-            assert.notEqual(clonedSuite, suite);
+            assert.deepEqual(clonedSuite, suite);
+            assert.notEqual(clonedSuite, suite); //not equal by link
+            assert.notEqual(clonedSuite.browsers, suite.browsers); //not equal by link
+        });
+
+        it('should clone all enumerable properties', () => {
+            const suite = createSuite('origin');
+            let value = 'some/path';
+            Object.defineProperty(suite, 'fullUrl', {
+                enumerable: true,
+                get: () => value
+            });
+            const clonedSuite = suite.clone();
+
+            assert.equal(clonedSuite.fullUrl, 'some/path');
+            value = 'another/path';
+            assert.equal(clonedSuite.fullUrl, 'another/path');
         });
 
         it('should clone nested suites', () => {


### PR DESCRIPTION
После решения задачи [про непроходимые ретраи](https://github.com/gemini-testing/gemini/pull/880), оказалось, что сьюты, которые кидаются на события, имеют неверный  `fullUrl` , который указывает на предыдущий сьют. А `fullUrl` корневого сьюта имеет значение  `undefined` . Это происходит, потому что сам сьют непраильно копирует геттер `fullUrl`. Ошибка приводит к тому, что в html-reporter'e выводится некорректная мета-юрл:
<img width="375" alt="fullurl" src="https://user-images.githubusercontent.com/25789153/36695646-97095646-1b4a-11e8-88d4-824f6fa4a0f5.png">

Пришлось слегка корректировать логику копирования сьютов
