### PR TITLE
WIP: add query methods

### DIFF
--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -103,7 +103,6 @@ module.exports = class NewBrowser extends Browser {
                     .then((calibration) => this._setCalibration(calibration));
             })
             .then(() => this.buildScripts())
-            .then(() => this.chooseLocator())
             .catch((e) => {
                 if (e.code === 'ECONNREFUSED') {
                     return Promise.reject(new GeminiError(
@@ -222,10 +221,6 @@ module.exports = class NewBrowser extends Browser {
         return this._calibration && this._calibration.needsCompatLib;
     }
 
-    chooseLocator() {
-        this.findElement = this._needsCompatLib ? this._findElementScript : this._findElementWd;
-    }
-
     reset() {
         // We can't use findElement here because it requires page with body tag
         return this.evalScript('document.body')
@@ -263,33 +258,14 @@ module.exports = class NewBrowser extends Browser {
             .then((handle) => this._wd.maximize(handle));
     }
 
-    findElement() {
-        throw new Error('findElement is called before appropriate locator is chosen');
-    }
+    findElement(selector, syntax = 'css') {
+        const locator = this._needsCompatLib ? ScriptLocator(this._clientBridge) : WdLocator(this._wd);
 
-    _findElementWd(selector) {
-        return this._wd.elementByCssSelector(selector)
-            .catch((error) => {
-                if (error.status === WdErrors.ELEMENT_NOT_FOUND) {
-                    error.selector = selector;
-                }
-                return Promise.reject(error);
-            });
-    }
+        if (!locator[syntax]) {
+            throw new Error(`${syntax} isn't supported by locator`);
+        }
 
-    _findElementScript(selector) {
-        return this._clientBridge.call('queryFirst', [selector])
-            .then((element) => {
-                if (element) {
-                    return element;
-                }
-
-                const error = new Error('Unable to find element');
-                error.status = WdErrors.ELEMENT_NOT_FOUND;
-                error.selector = selector;
-
-                return Promise.reject(error);
-            });
+        return locator[syntax](selector);
     }
 
     prepareScreenshot(selectors, opts) {
@@ -317,3 +293,38 @@ module.exports = class NewBrowser extends Browser {
         return `[${this.id} (${this.sessionId})]`;
     }
 };
+
+function WdLocator(wd) {
+    const tryFind = (find) => (selector) => find(selector)
+            .catch((error) => {
+                if (error.status === WdErrors.ELEMENT_NOT_FOUND) {
+                    error.selector = selector;
+                }
+                return Promise.reject(error);
+            });
+
+    return {
+        css: tryFind(wd.elementByCssSelector.bind(wd)),
+        link: tryFind(wd.elementByLinkText.bind(wd)),
+        xpath: tryFind(wd.elementByXPath.bind(wd))
+    };
+}
+
+function ScriptLocator(clientBridge) {
+    return {
+        css(selector) {
+            return clientBridge.call('queryFirst', [selector])
+                .then((element) => {
+                    if (element) {
+                        return element;
+                    }
+
+                    const error = new Error('Unable to find element');
+                    error.status = WdErrors.ELEMENT_NOT_FOUND;
+                    error.selector = selector;
+
+                    return Promise.reject(error);
+                });
+        }
+    };
+}

--- a/lib/tests-api/actions-builder.js
+++ b/lib/tests-api/actions-builder.js
@@ -379,7 +379,7 @@ function findElement(element, browser) {
         element = find(element);
     }
 
-    return browser.findElement(element._selector)
+    return browser.findElement(element._selector, element._syntax)
         .then((foundElement) => {
             element.cache = element.cache || {};
             element.cache[browser.sessionId] = foundElement;

--- a/lib/tests-api/find-func.js
+++ b/lib/tests-api/find-func.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.find = function(selector) {
+function createElementFinder(selector, syntax) {
     if (typeof selector !== 'string') {
         throw new Error('find argument should be a string');
     }
@@ -10,6 +10,17 @@ exports.find = function(selector) {
             value: selector,
             enumerable: false,
             writable: false
+        },
+        _syntax: {
+            value: syntax,
+            enumerable: false,
+            writable: false
         }
     });
-};
+}
+
+exports.find = Object.assign(
+    (selector) => createElementFinder(selector, 'css'),
+    ['css', 'link', 'xpath']
+        .reduce((o, syntax) => Object.assign(o, {[syntax]: selector => createElementFinder(selector, syntax)}), {})
+);

--- a/test/unit/browser/new-browser.js
+++ b/test/unit/browser/new-browser.js
@@ -27,6 +27,8 @@ describe('browser/new-browser', () => {
             windowHandle: sinon.stub().returns(Promise.resolve({})),
             moveTo: sinon.stub().returns(Promise.resolve()),
             elementByCssSelector: sinon.stub().returns(Promise.resolve()),
+            elementByLinkText: sinon.stub().returns(Promise.resolve()),
+            elementByXPath: sinon.stub().returns(Promise.resolve()),
             on: sinon.stub(),
             currentContext: sinon.stub().returns(Promise.resolve()),
             context: sinon.stub().returns(Promise.resolve()),

--- a/test/unit/browser/new-browser.js
+++ b/test/unit/browser/new-browser.js
@@ -413,8 +413,6 @@ describe('browser/new-browser', () => {
 
         beforeEach(() => {
             browser = makeBrowser({browserName: 'browser', version: '1.0'});
-
-            browser.chooseLocator();
         });
 
         it('should reset mouse position', () => {


### PR DESCRIPTION
PR to extend `find` with additional query methods:
```javascript
.before((actions, find) => {
  actions.click(find(".link")) 
  actions.click(find.link("Click Me"))
})
```

- [x] css
- [x] link
- [x] xpath
- [ ] a11y
(https://github.com/admc/wd/blob/master/doc/api.md)

Supersedes #896