### PR TITLE
chore(wd): upgraded `wd` from ^0.4.0 to ^1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -126,59 +135,25 @@
       "integrity": "sha1-pqxTaEUPIJufW4bpo+Smq2/nUxw=",
       "dev": true
     },
-    "archiver": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
-      "integrity": "sha1-W53bn17hzu8hy487Ag5iQOy0MVw=",
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "requires": {
-        "async": "0.9.2",
-        "buffer-crc32": "0.2.13",
-        "glob": "4.3.5",
-        "lazystream": "0.1.0",
-        "lodash": "3.2.0",
-        "readable-stream": "1.0.34",
-        "tar-stream": "1.1.5",
-        "zip-stream": "0.5.2"
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.5",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "glob": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-          "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
+        "lazystream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+          "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
-          }
-        },
-        "lodash": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs="
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "readable-stream": "2.3.3"
           }
         }
       }
@@ -257,11 +232,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
-    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -279,11 +249,6 @@
       "requires": {
         "util": "0.10.3"
       }
-    },
-    "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -315,24 +280,17 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
       "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
     },
-    "aws-sign2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
-    },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -386,31 +344,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
-      }
-    },
-    "bl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        }
       }
     },
     "bluebird": {
@@ -427,6 +363,7 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -460,9 +397,9 @@
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.4.tgz",
       "integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
       "requires": {
+        "JSONStream": "1.3.2",
         "combine-source-map": "0.8.0",
         "defined": "1.0.0",
-        "JSONStream": "1.3.2",
         "safe-buffer": "5.1.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
@@ -488,6 +425,7 @@
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "requires": {
+        "JSONStream": "1.3.2",
         "assert": "1.4.1",
         "browser-pack": "6.0.4",
         "browser-resolve": "1.11.2",
@@ -509,7 +447,6 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.2",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -627,10 +564,29 @@
         }
       }
     },
+    "buffer-alloc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
+      "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+      "requires": {
+        "buffer-alloc-unsafe": "0.1.1",
+        "buffer-fill": "0.1.1"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
+      "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-fill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
+      "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -690,11 +646,6 @@
           "dev": true
         }
       }
-    },
-    "caseless": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-      "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g="
     },
     "center-align": {
       "version": "0.1.3",
@@ -790,8 +741,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coa": {
       "version": "1.0.4",
@@ -828,14 +778,6 @@
         "source-map": "0.5.7"
       }
     },
-    "combined-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "requires": {
-        "delayed-stream": "0.0.5"
-      }
-    },
     "commander": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
@@ -849,30 +791,6 @@
       "requires": {
         "array-ify": "1.0.0",
         "dot-prop": "3.0.0"
-      }
-    },
-    "compress-commons": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
-      "integrity": "sha1-Qi2SdDDAGr0GzUVbbfwEy0z4ADw=",
-      "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "0.3.4",
-        "node-int64": "0.3.3",
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        }
       }
     },
     "concat-map": {
@@ -1009,8 +927,8 @@
           "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
           "dev": true,
           "requires": {
-            "is-text-path": "1.0.1",
             "JSONStream": "1.3.2",
+            "is-text-path": "1.0.1",
             "lodash": "4.17.5",
             "meow": "3.7.0",
             "split2": "2.2.0",
@@ -1159,8 +1077,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.5",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -1189,8 +1107,8 @@
           "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
           "dev": true,
           "requires": {
-            "is-text-path": "1.0.1",
             "JSONStream": "1.3.2",
+            "is-text-path": "1.0.1",
             "lodash": "4.17.5",
             "meow": "3.7.0",
             "split2": "2.2.0",
@@ -1406,27 +1324,10 @@
         }
       }
     },
-    "crc32-stream": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
-      "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
-      "requires": {
-        "buffer-crc32": "0.2.13",
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        }
-      }
+    "crc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -1488,6 +1389,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -1531,11 +1433,6 @@
         }
       }
     },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1567,7 +1464,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -1575,8 +1471,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -1664,11 +1559,6 @@
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2"
       }
-    },
-    "delayed-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
     },
     "deps-sort": {
       "version": "2.0.0",
@@ -1778,7 +1668,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -2164,8 +2053,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "falafel": {
       "version": "1.2.0",
@@ -2177,6 +2065,16 @@
         "isarray": "0.0.1",
         "object-keys": "1.0.11"
       }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2276,23 +2174,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
-    "form-data": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-      "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
-      "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime-types": "2.0.14"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        }
-      }
-    },
     "formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
@@ -2319,6 +2200,11 @@
       "requires": {
         "null-check": "1.0.0"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "0.30.0",
@@ -2433,12 +2319,14 @@
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
       "requires": {
         "is-property": "1.0.2"
       }
@@ -2478,7 +2366,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -2486,8 +2373,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -2769,23 +2655,10 @@
         }
       }
     },
-    "har-validator": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-      "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
-      "requires": {
-        "bluebird": "2.11.0",
-        "chalk": "1.1.3",
-        "commander": "2.13.0",
-        "is-my-json-valid": "2.17.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-        }
-      }
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "has": {
       "version": "1.0.1",
@@ -2826,17 +2699,6 @@
         "minimalistic-assert": "1.0.0"
       }
     },
-    "hawk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2850,7 +2712,8 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -2862,16 +2725,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
-    },
-    "http-signature": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-      "requires": {
-        "asn1": "0.1.11",
-        "assert-plus": "0.1.5",
-        "ctype": "0.5.3"
-      }
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -2991,10 +2844,10 @@
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "requires": {
+        "JSONStream": "1.3.2",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.6",
-        "JSONStream": "1.3.2",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -3108,6 +2961,7 @@
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
       "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "dev": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
@@ -3172,7 +3026,8 @@
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -3203,8 +3058,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -3362,14 +3216,17 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "0.0.1",
@@ -3405,22 +3262,13 @@
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -3431,8 +3279,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -3466,27 +3313,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
-    "lazystream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
-      "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        }
-      }
     },
     "lcid": {
       "version": "1.0.0",
@@ -3720,19 +3546,6 @@
         "brorand": "1.1.0"
       }
     },
-    "mime-db": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-      "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
-    },
-    "mime-types": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-      "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-      "requires": {
-        "mime-db": "1.12.0"
-      }
-    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -3766,7 +3579,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3774,8 +3586,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -3863,6 +3674,7 @@
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "requires": {
+        "JSONStream": "1.3.2",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -3870,7 +3682,6 @@
         "detective": "4.7.1",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.2",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.5.0",
@@ -3940,16 +3751,6 @@
         "is-stream": "1.1.0"
       }
     },
-    "node-int64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
-      "integrity": "sha1-LW5rLs5d6FiLQ9iNG8QbJs0fqE0="
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -3985,6 +3786,7 @@
       "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "abbrev": "1.1.0",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -4016,7 +3818,6 @@
         "inherits": "2.0.3",
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
-        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "lockfile": "1.0.3",
         "lodash._baseindexof": "3.1.0",
@@ -4083,6 +3884,27 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true,
@@ -4491,27 +4313,6 @@
               "requires": {
                 "read": "1.0.7"
               }
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true,
-              "dev": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -8577,11 +8378,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "oauth-sign": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-      "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM="
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8835,6 +8631,11 @@
         "sha.js": "2.4.10"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -8967,11 +8768,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-      "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o="
     },
     "querystring": {
       "version": "0.2.0",
@@ -9173,31 +8969,6 @@
       "dev": true,
       "requires": {
         "is-finite": "1.0.2"
-      }
-    },
-    "request": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-      "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
-      "requires": {
-        "aws-sign2": "0.5.0",
-        "bl": "0.9.5",
-        "caseless": "0.9.0",
-        "combined-stream": "0.0.7",
-        "forever-agent": "0.6.1",
-        "form-data": "0.2.0",
-        "har-validator": "1.8.0",
-        "hawk": "2.3.1",
-        "http-signature": "0.10.1",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.0.14",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.6.0",
-        "qs": "2.4.2",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.4.3"
       }
     },
     "require-directory": {
@@ -9426,6 +9197,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -9499,7 +9271,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -9514,14 +9285,12 @@
         "asn1": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -9723,11 +9492,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -9738,6 +9502,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -9863,30 +9632,6 @@
         }
       }
     },
-    "tar-stream": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
-      "integrity": "sha1-vpIYwTDCACnhB7D5Z/sj3gV50Tw=",
-      "requires": {
-        "bl": "0.9.5",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        }
-      }
-    },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -9975,6 +9720,11 @@
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
     "to-iso-string": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
@@ -10018,13 +9768,13 @@
     "tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -10092,11 +9842,6 @@
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
       "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4="
     },
-    "underscore.string": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
-      "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI="
-    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -10152,6 +9897,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -10171,7 +9921,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -10181,8 +9930,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -10194,34 +9942,339 @@
         "indexof": "0.0.1"
       }
     },
+    "walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    },
     "wd": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-0.4.0.tgz",
-      "integrity": "sha1-9vSk4gL2ikt2h652WusTDIQ0H5o=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.6.2.tgz",
+      "integrity": "sha512-QWfLPcChqM4yu0b+thRP4QIsvqqlu/HWRQXBNY/+j60yJ/D4Kk+g9i6JOo5JMuWPVGGARIVhzbr4j9dIMAr7wg==",
       "requires": {
-        "archiver": "0.14.4",
-        "async": "1.0.0",
-        "lodash": "3.9.3",
+        "archiver": "1.3.0",
+        "async": "2.0.1",
+        "lodash": "4.16.2",
+        "mkdirp": "0.5.1",
         "q": "1.4.1",
-        "request": "2.55.0",
-        "underscore.string": "3.0.3",
+        "request": "2.85.0",
+        "underscore.string": "3.3.4",
         "vargs": "0.1.0"
       },
       "dependencies": {
-        "async": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "archiver": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+          "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+          "requires": {
+            "archiver-utils": "1.3.0",
+            "async": "2.0.1",
+            "buffer-crc32": "0.2.13",
+            "glob": "7.1.2",
+            "lodash": "4.16.2",
+            "readable-stream": "2.3.3",
+            "tar-stream": "1.6.1",
+            "walkdir": "0.0.11",
+            "zip-stream": "1.2.0"
+          }
+        },
+        "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "requires": {
+            "lodash": "4.16.2"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "bl": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "requires": {
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
+              }
+            }
+          }
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "compress-commons": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+          "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+          "requires": {
+            "buffer-crc32": "0.2.13",
+            "crc32-stream": "2.0.0",
+            "normalize-path": "2.1.1",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "crc32-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+          "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+          "requires": {
+            "crc": "3.5.0",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI="
+          "version": "4.16.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz",
+          "integrity": "sha1-PmJtuCcEimmSgaihJSJjJs/A5lI="
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "q": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
           "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "request": {
+          "version": "2.85.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+          "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+          "requires": {
+            "bl": "1.2.2",
+            "buffer-alloc": "1.1.0",
+            "end-of-stream": "1.4.1",
+            "fs-constants": "1.0.0",
+            "readable-stream": "2.3.3",
+            "to-buffer": "1.1.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "underscore.string": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+          "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+          "requires": {
+            "sprintf-js": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "zip-stream": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+          "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+          "requires": {
+            "archiver-utils": "1.3.0",
+            "compress-commons": "1.2.2",
+            "lodash": "4.16.2",
+            "readable-stream": "2.3.3"
+          }
         }
       }
     },
@@ -10325,34 +10378,6 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
-        }
-      }
-    },
-    "zip-stream": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
-      "integrity": "sha1-Mty8UG0Nq00hNyYlvX66rDwv/1Y=",
-      "requires": {
-        "compress-commons": "0.2.9",
-        "lodash": "3.2.0",
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sizzle": "^2.2.0",
     "source-map": "^0.5.3",
     "striptags": "2.1.1",
-    "wd": "^0.4.0",
+    "wd": "^1.6.2",
     "worker-farm": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**wd@0.4.0** uses `os.tmpDir()` which is deprecated
Fixes #912