### PR TITLE
feat: Add ability to pass any event arguments via PassthroughEmitter

### DIFF
--- a/lib/passthrough-emitter.js
+++ b/lib/passthrough-emitter.js
@@ -1,16 +1,14 @@
 'use strict';
 
-const _ = require('lodash'),
-    AsyncEmitter = require('gemini-core').events.AsyncEmitter;
+const _ = require('lodash');
+const AsyncEmitter = require('gemini-core').events.AsyncEmitter;
+
+const ASYNC_FLAG = 'async';
+const markAsAsync = (args) => !args.includes(ASYNC_FLAG) ? args.concat(ASYNC_FLAG) : args;
 
 module.exports = class PassthroughEmitter extends AsyncEmitter {
-    // Allow to pass only one argument with event
-    emit(type, data) {
-        return super.emit(type, data);
-    }
-
-    emitAndWait(type, data) {
-        return super.emitAndWait(type, data, {shouldWait: true});
+    emitAndWait(type, ...args) {
+        return super.emitAndWait(type, ...markAsAsync(args));
     }
 
     /**
@@ -24,11 +22,11 @@ module.exports = class PassthroughEmitter extends AsyncEmitter {
             return;
         }
 
-        emitter.on(event, function(data, opts) {
-            if (opts && opts.shouldWait) {
-                return this.emitAndWait(event, data);
+        emitter.on(event, function(...args) {
+            if (args.includes(ASYNC_FLAG)) {
+                return this.emitAndWait(event, ...args);
             } else {
-                this.emit(event, data);
+                this.emit(event, ...args);
             }
         }.bind(this));
     }

--- a/test/unit/passthrough-emitter.js
+++ b/test/unit/passthrough-emitter.js
@@ -1,7 +1,7 @@
 'use strict';
 const PassthroughEmitter = require('lib/passthrough-emitter');
 
-describe('PassthroughEmitter', () => {
+describe.only('PassthroughEmitter', () => {
     let runner,
         child;
 
@@ -44,6 +44,18 @@ describe('PassthroughEmitter', () => {
         return child.emitAndWait('some-event')
             .then((data) => {
                 assert.equal(data, 'some-data');
+            });
+    });
+
+    it('should be able to pass multiple event arguments', () => {
+        runner.passthroughEvent(child, 'some-event');
+        runner.on('some-event', function(...args) {
+            return `some-data ${args[0]} ${args[1]}`;
+        });
+
+        return child.emitAndWait('some-event', 'foo', 'bar')
+            .then((data) => {
+                assert.equal(data, `some-data foo bar`);
             });
     });
 });


### PR DESCRIPTION
Текущий PassthroughEmitter имеет 1 "фатальный недостаток": можно использовать только 1 параметр для события.

Данный пулл-реквест устраняет это ограничение.

P.S. текущие юнит тесты на `PassthroughEmitter` написаны неправильно, так как используется `assert.equal` вместо `assert.eql`.

Например существующий тест:
```js
it('should not break promise chain on event emitted by emitAndWait', () => {
        runner.passthroughEvent(child, 'some-event');
        runner.on('some-event', function() {
            return 'some-data';
        });

        return child.emitAndWait('some-event')
            .then((data) => {
                assert.equal(data, 'some-data');
            });
    });
```

Здесь data, которая возвращается из промиса - это фактически двойной вложенный массив, который образуется путем двухкратного применения `waitForResults` из `emitAndWait` класса `AsyncEmitter` в gemini-core. Т.е. реальное значение `data` - это `[['some-data']]`.

Корректно данная проверка выглядела бы следующим образом:

```js
it('should not break promise chain on event emitted by emitAndWait', () => {
        runner.passthroughEvent(child, 'some-event');
        runner.on('some-event', function() {
            return 'some-data';
        });

        return child.emitAndWait('some-event')
            .then((data) => {
                assert.eql(data[0][0], 'some-data');
            });
    });
```

То, что сейчас этот тест проходит - это особенность работы assert.equal