### PR TITLE
chore: drop node versions previous to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 script: npm run ${NPM_SCRIPT}
 after_success: cat ${TRAVIS_BUILD_DIR}/coverage/lcov.info | coveralls
 node_js:
-  - '6'
   - '8'
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.0",
   "description": "UI Screenshot testing utility",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "bin": {
     "gemini": "./bin/gemini"


### PR DESCRIPTION
BREAKING CHANGE: now supported version of node >= 8.0.0