### PR TITLE
Monkey patch to fix firefox 64

### DIFF
--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -240,7 +240,15 @@ module.exports = class NewBrowser extends Browser {
     reset() {
         // We can't use findElement here because it requires page with body tag
         return this.evalScript('document.body')
-            .then(body => this._wd.moveTo(body, 0, 0))
+            .then(body => {
+                const keys = Object.keys(body);
+                let bodyObjOrId = body;
+                if (keys.length === 1) {
+                    const key = keys[0];
+                    bodyObjOrId = body[key];
+                }
+                return this._wd.moveTo(bodyObjOrId, 0, 0);
+            })
             .catch(e => {
                 return Promise.reject(_.extend(e || {}, {
                     browserId: this.id,


### PR DESCRIPTION
Hello and thanks for gemini, Yandex!

This PR is not really about merging but it's about an issue which maybe should be fixed in wd dependency or any other way.

I just update firefox from 57 to 64 and an error:

```
message: [moveTo({"element-6066-11e4-a52e-4f735466cecf":"a5065917-0c70-40b1-97d5-56bdd50d9cef"},0,0)]
Error response status: 7, NoSuchElement -
An element could not be located on the page using the given search parameters.
Selenium error: Web element reference not seen before: [object Object]
For documentation on this error, please visit: https://www.seleniumhq.org/exceptions/no_such_element.html
```

So I look at messages:

At request:
```
POST /wd/hub/session/id/execute HTTP/1.0
{
    "script": "return document.body;",
    "args": []
}
```

Firefox 57 responses:
```
200
{
    "state": "success",
    "sessionId": "2644713",
    "hCode": 1745162925,
    "value": {
        "element-6066-11e4-a52e-4f735466cecf": "f7905fa4-4cf4-4830-8b58-63b75f49b101",
        "ELEMENT": "f7905fa4-4cf4-4830-8b58-63b75f49b101",
        "screen": ""
    },
    "class": "org.openqa.selenium.remote.Response",
    "status": 0
}
```

Firefox 64 responses:
```
200
{
    "state": "success",
    "sessionId": "2644710",
    "class": "org.openqa.selenium.remote.Response",
    "value": {
        "element-6066-11e4-a52e-4f735466cecf": "8cffb82c-dcf8-4953-b4dc-e048e5844478"
    },
    "status": 0
}
```

I found this lines of code and logged `body` var:
From firefox 64 it is:
```
Element {
  value: '022e6bbc-3541-41d2-b624-19d6201b3ea6',
  browser: 
   EventEmitter {
     domain: null,
     _events: 
      { connection: [Function],
        status: [Function],
        command: [Function] },
     _eventsCount: 3,
     _maxListeners: undefined,
     configUrl: 
      Url {
        protocol: 'http:',
        slashes: true,
        auth: null,
        host: 'vmmaster.test:9000',
        port: '9000',
        hostname: 'vmmaster.test',
        hash: null,
        search: null,
        query: null,
        pathname: '/wd/hub',
        path: '/wd/hub',
        href: 'http://vmmaster.test:9000/wd/hub' },
     sauceTestPageRoot: 'https://saucelabs.com/jobs',
     sauceRestRoot: 'https://saucelabs.com/rest/v1',
     noAuthConfigUrl: 
      Url {
        protocol: 'http:',
        slashes: true,
        host: 'vmmaster.test:9000',
        port: '9000',
        hostname: 'vmmaster.test',
        hash: null,
        search: null,
        query: null,
        pathname: '/wd/hub',
        path: '/wd/hub',
        href: 'http://vmmaster.test:9000/wd/hub' },
     defaultCapabilities: 
      { browserName: 'firefox',
        version: '',
        javascriptEnabled: true,
        platform: 'ANY' },
     _httpConfig: 
      { timeout: 100000,
        retries: -1,
        retryDelay: 15,
        baseUrl: undefined,
        proxy: undefined,
        rejectUnauthorized: true },
     sessionID: '2644702' } }
```

From firefox 57 it is just
```
{ 'element-6066-11e4-a52e-4f735466cecf': 'cae89f4a-9fb2-42a9-b019-2cbd87fc013a' }
```
And when it converts to string it is `[object Object]`

So I just looked to `node_modules/wd/lib/element.js` (toString method) and got that the object should just return ID. That's what I've done and all test passed.

Is it `wd` problem? Or may be fixed here? Have you got any issues like that or it's new?

I use gemini 7.0.1
firefox 64.0
selenium 3.141.59
gecko driver 0.23.0