### PR TITLE
fix: make executeJS method work properly with arrow function

### DIFF
--- a/lib/tests-api/actions-builder.js
+++ b/lib/tests-api/actions-builder.js
@@ -387,7 +387,7 @@ function replaceStack(error, stack) {
 }
 
 function serializeFunc(func, args) {
-    return '(' + func.toString() + (_.isEmpty(args) ? '(window));' : `(window, '${args.join('\', \'')}'));`);
+    return '(' + func.toString() + (_.isEmpty(args) ? ')(window);' : `)(window, '${args.join('\', \'')}');`);
 }
 
 function findElement(element, browser) {


### PR DESCRIPTION
Fixes #953.

Used another way to define IIFE that works properly with arrow functions.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.