### PR TITLE
fix: update png-img to 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -239,6 +239,11 @@
       "integrity": "sha1-pqxTaEUPIJufW4bpo+Smq2/nUxw=",
       "dev": true
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://npm.yandex-team.ru/aproba/-/aproba-1.2.0.tgz?rbtorrent=8e2b42f37b6bb610086bf7a3cd719f5e06aa616b",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
     "archiver": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
@@ -275,6 +280,15 @@
         "lodash": "^4.8.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://npm.yandex-team.ru/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz?rbtorrent=ba98361f452efe66671f77b624039036f5fee2d9",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -918,6 +932,11 @@
         "supports-color": "^2.0.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://npm.yandex-team.ru/chownr/-/chownr-1.1.4.tgz?rbtorrent=87a15cb4833896803bf13a8008f0f5280eed549d",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1002,8 +1021,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1124,6 +1142,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://npm.yandex-team.ru/console-control-strings/-/console-control-strings-1.1.0.tgz?rbtorrent=0e1f5023632091b0b84d974a95da71e6feb7b413",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2284,6 +2307,14 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "http://npm.yandex-team.ru/decompress-response/-/decompress-response-4.2.1.tgz?rbtorrent=73b1bb0d81c3a247cb0c3d1cc8f59e181310318c",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -2360,6 +2391,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://npm.yandex-team.ru/delegates/-/delegates-1.0.0.tgz?rbtorrent=804639b51898a367b8ef98ac57d34edbeb698e0c",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "deps-sort": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
@@ -2379,6 +2415,11 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://npm.yandex-team.ru/detect-libc/-/detect-libc-1.0.3.tgz?rbtorrent=b64e4119f2b8684ece543716a33acb4bc6e6eba6",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detective": {
       "version": "4.7.1",
@@ -2904,6 +2945,11 @@
         }
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://npm.yandex-team.ru/expand-template/-/expand-template-2.0.3.tgz?rbtorrent=83cf95d9a0c7df5cb14eee7271fe383f4620815e",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "extend": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
@@ -3234,6 +3280,21 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "http://npm.yandex-team.ru/gauge/-/gauge-2.7.4.tgz?rbtorrent=a999855bd3603c960ed07b346eb7528f48626c56",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
     "gemini-configparser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.0.0.tgz",
@@ -3256,7 +3317,7 @@
         "lodash": "^4.15.0",
         "looks-same": "^7.1.1",
         "micromatch": "^4.0.2",
-        "png-img": "^2.1.1",
+        "png-img": "^3.3.0",
         "sizzle": "^2.3.3",
         "temp": "^0.8.3",
         "uglify-js": "^2.8.29",
@@ -3765,6 +3826,11 @@
         "ini": "^1.3.2"
       }
     },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://npm.yandex-team.ru/github-from-package/-/github-from-package-0.0.0.tgz?rbtorrent=23cd242128d93fe8cf282afbe18f7c19d85a8ca8",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
     "github-url-from-git": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
@@ -3961,6 +4027,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://npm.yandex-team.ru/has-unicode/-/has-unicode-2.0.1.tgz?rbtorrent=e09166df87126e830d7ad36ef4eea165acf1d616",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -4283,8 +4354,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inline-source-map": {
       "version": "0.6.2",
@@ -4472,7 +4542,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -5214,6 +5283,11 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://npm.yandex-team.ru/mimic-response/-/mimic-response-2.1.0.tgz?rbtorrent=80055022898caa08ff9a1f884d90c770fe975767",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5280,6 +5354,11 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://npm.yandex-team.ru/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz?rbtorrent=468cb8276ca3d472b48f039ffc822d9d607d4982",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mocha": {
       "version": "2.5.3",
@@ -5417,9 +5496,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "2.14.2",
+      "resolved": "https://npm.yandex-team.ru/nan/-/nan-2.14.2.tgz?rbtorrent=6d285c8ec1df745cfa19ff86d2a1aa0001abfb4f",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5438,6 +5517,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://npm.yandex-team.ru/napi-build-utils/-/napi-build-utils-1.0.2.tgz?rbtorrent=eb34ef1f80b4b3f883a1819c112ce5cb524a1d06",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "native-promise-only": {
       "version": "0.8.1",
@@ -5468,6 +5552,14 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-abi": {
+      "version": "2.26.0",
+      "resolved": "https://npm.yandex-team.ru/node-abi/-/node-abi-2.26.0.tgz?rbtorrent=8380b8b08b5d5f941a0b830b2ccff931160bb52e",
+      "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -5476,6 +5568,11 @@
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://npm.yandex-team.ru/noop-logger/-/noop-logger-0.1.1.tgz?rbtorrent=8caaafa7d4a3cb8fb306e6c077c1302c24314372",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "nopt": {
       "version": "3.0.6",
@@ -10092,6 +10189,17 @@
         }
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "http://npm.yandex-team.ru/npmlog/-/npmlog-4.1.2.tgz?rbtorrent=d00c8c497d901e038c3260b30a4d0a696f5368a9",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
     "null-check": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
@@ -10101,8 +10209,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -10553,11 +10660,12 @@
       "dev": true
     },
     "png-img": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/png-img/-/png-img-2.2.0.tgz",
-      "integrity": "sha512-rdWIsOuM9NH8fZUUa098Y1GmPjysadTwTYOBNM6JeteBX5NShLtq/aBomfb48d/Q4bNe+H3g5FvH0UD+LiAN1g==",
+      "version": "3.3.0",
+      "resolved": "https://npm.yandex-team.ru/png-img/-/png-img-3.3.0.tgz?rbtorrent=5be55724f06c8d276cac0287ea88f6032c895760",
+      "integrity": "sha512-WUCQ6X01lxbkbRUWcu5QnQ11SLP992EHhC8vyri1T3pnOu58vRlMnWJnWt9lFUd48PHDYGRCe6TldffNo4I+ng==",
       "requires": {
-        "nan": "^2.0.4"
+        "nan": "^2.14.0",
+        "prebuild-install": "^5.3.5"
       }
     },
     "pngjs": {
@@ -10575,6 +10683,51 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "prebuild-install": {
+      "version": "5.3.6",
+      "resolved": "https://npm.yandex-team.ru/prebuild-install/-/prebuild-install-5.3.6.tgz?rbtorrent=0cf39e4310628e0f3747e94070e72a20ba6d4ab5",
+      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "http://npm.yandex-team.ru/deep-extend/-/deep-extend-0.6.0.tgz?rbtorrent=ef6dac683cfd6fead38ad663236e66b23f1b66f3",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "http://npm.yandex-team.ru/minimist/-/minimist-1.2.5.tgz?rbtorrent=d177ecf8bc0475c4b5713dde5520e90dc38ac8a3",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "rc": {
+          "version": "1.2.8",
+          "resolved": "http://npm.yandex-team.ru/rc/-/rc-1.2.8.tgz?rbtorrent=2ce0e6a316b9ac26e8560eb7de3519872152eda1",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -10655,7 +10808,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -11036,8 +11188,7 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -11048,8 +11199,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.0",
@@ -11138,13 +11288,22 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://npm.yandex-team.ru/simple-get/-/simple-get-3.1.0.tgz?rbtorrent=e2deacbe5021bb42483e416eb4bf27def31b5f27",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "sinon": {
       "version": "2.4.1",
@@ -11621,7 +11780,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -11682,8 +11840,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "striptags": {
       "version": "2.1.1",
@@ -11773,6 +11930,90 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://npm.yandex-team.ru/tar-fs/-/tar-fs-2.1.1.tgz?rbtorrent=9414ec1a7b6a192759dca018d3c0cef45b779084",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "http://npm.yandex-team.ru/base64-js/-/base64-js-1.5.1.tgz?rbtorrent=c7446c2f65a00b903f15ca23ad4f95c446f448c8",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://npm.yandex-team.ru/bl/-/bl-4.1.0.tgz?rbtorrent=9355e759d336df22a71851b996fab75ed41c57a3",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://npm.yandex-team.ru/inherits/-/inherits-2.0.4.tgz?rbtorrent=6d3c5e553faab1c5a0e5657d5f75d80d275fddbe",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            }
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://npm.yandex-team.ru/buffer/-/buffer-5.7.1.tgz?rbtorrent=0575f1d8f9cc38aee8a5d5c6548097df60fdd042",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://npm.yandex-team.ru/ieee754/-/ieee754-1.2.1.tgz?rbtorrent=f8c89388fdebc540fdd36fd4340d98c1f30d2e17",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://npm.yandex-team.ru/readable-stream/-/readable-stream-3.6.0.tgz?rbtorrent=43330b275a87977a7a63c7a19aadc328cfeab61c",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "http://npm.yandex-team.ru/safe-buffer/-/safe-buffer-5.2.1.tgz?rbtorrent=e3149b0255bb4dc4e498c9b879904dfcfa607eba",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "http://npm.yandex-team.ru/string_decoder/-/string_decoder-1.3.0.tgz?rbtorrent=6fcc818c75109a0c34b6a6b2a760bd239d9462b9",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "tar-stream": {
+          "version": "2.2.0",
+          "resolved": "http://npm.yandex-team.ru/tar-stream/-/tar-stream-2.2.0.tgz?rbtorrent=87758faec2346e259a48e516dce880b8af4c101f",
+          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+          "requires": {
+            "bl": "^4.0.3",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
           }
         }
       }
@@ -12261,6 +12502,19 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://npm.yandex-team.ru/which-pm-runs/-/which-pm-runs-1.0.0.tgz?rbtorrent=d9e1fda7822d2c8a547656d7d38a84d30f2a6ce3",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://npm.yandex-team.ru/wide-align/-/wide-align-1.1.3.tgz?rbtorrent=75cbc12ad9f4206005f64041831147ee76e9aa28",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "window-size": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "micromatch": "^2.3.11",
     "node-fetch": "^1.6.3",
     "plugins-loader": "^1.1.0",
-    "png-img": "^2.1.0",
+    "png-img": "^3.3.0",
     "resolve": "^1.1.0",
     "sizzle": "^2.2.0",
     "source-map": "^0.5.3",


### PR DESCRIPTION
Fixes issue https://github.com/gemini-testing/gemini/issues/985

Had to hack lock file a little because gemini-core@3 also has `png-img@2` as dependency.

By the way, latest version of gemini-core already has `png-img@3` as a dependency, may be we could update to it?
Otherwise, we will have to make patch versions for currently used here `gemini-core@3`.